### PR TITLE
Install shell completions directly

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ before:
   hooks:
     - go mod tidy
     - go generate ./...
+    - ./scripts/completions.sh
 
 builds:
   - <<: &build_defaults
@@ -37,6 +38,7 @@ archives:
     format: tar.gz
     files:
       - LICENSE
+      - completions/*
   - id: windows
     builds: [windows]
     <<: *archive_defaults
@@ -68,4 +70,7 @@ brews:
     description: Algolia CLI utility
     install: |
       bin.install "algolia"
+      bash_completion.install "completions/algolia.bash" => "algolia"
+      zsh_completion.install "completions/algolia.zsh" => "_algolia"
+      fish_completion.install "completions/algolia.fish"
     caveats: "❤ Thanks for installing the Algolia CLI!"

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+rm -rf completions
+mkdir completions
+for sh in bash zsh fish; do
+	go run cmd/algolia/main.go completion "$sh" >"completions/algolia.$sh"
+done


### PR DESCRIPTION
The shell completion will be now part of the release archives, and we will use the `HomeBrew` `completion` feature to automatically install the completion for the supported types of shell.