### PR TITLE
Automatically publish the docs `.yml` files on release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -27,17 +27,17 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-      # - name: Docs checkout
-      #   uses: actions/checkout@v3
-      #   with:
-      #     repository: algolia/cli-docs
-      #     path: docs
-      #     fetch-depth: 0
-      #     token: ${{secrets.GORELEASER_GITHUB_TOKEN}}
-      # - name: Update docs
-      #   env:
-      #     GIT_COMMITTER_NAME: algolia-ci
-      #     GIT_AUTHOR_NAME: algolia-ci
-      #     GIT_COMMITTER_EMAIL: noreply@algolia.com
-      #     GIT_AUTHOR_EMAIL: noreply@algolia.com
-      #   run: make docs-bump
+      - name: Docs checkout
+        uses: actions/checkout@v3
+        with:
+          repository: algolia/doc
+          path: docs
+          fetch-depth: 0
+          token: ${{secrets.GORELEASER_GITHUB_TOKEN}}
+      - name: Update docs
+        env:
+          GIT_COMMITTER_NAME: algolia-ci
+          GIT_AUTHOR_NAME: algolia-ci
+          GIT_COMMITTER_EMAIL: noreply@algolia.com
+          GIT_AUTHOR_EMAIL: noreply@algolia.com
+        run: make docs-bump

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,15 @@ test:
 
 ## Build & publish the documentation
 docs:
-	git clone https://github.com/algolia/cli-docs.git "$@"
+	git clone https://github.com/algolia/doc.git "$@"
 
 docs-bump: docs
 	git -C docs pull
-	git -C docs rm 'algolia_*.md' 2>/dev/null || true
-	go run ./cmd/docs --doc-path docs
-	rm -f docs/*.bak
-	git -C docs add 'algolia*.md'
-	git -C docs commit -m 'update docs' || true
+	git -C docs checkout feat/cli 
+	git -C docs rm 'app_data/cli/commands/*.yml' 2>/dev/null || true
+	go run ./cmd/docs --app_data-path docs/app_data/cli/commands
+	git -C docs add 'app_data/cli/commands/*.yml'
+	git -C docs commit -m 'update cli commands app data' || true
 	git -C docs push
 .PHONY: docs-bump
 

--- a/pkg/cmdutil/jsonpath_flags.go
+++ b/pkg/cmdutil/jsonpath_flags.go
@@ -104,10 +104,12 @@ func (f *JSONPathPrintFlags) ToPrinter(templateFormat string) (printers.Printer,
 func (f *JSONPathPrintFlags) AddFlags(c *cobra.Command) {
 	if f.TemplateArgument != nil {
 		c.Flags().StringVar(f.TemplateArgument, "template", *f.TemplateArgument, "Template string or path to template file to use when --output=jsonpath, --output=jsonpath-file.")
+		_ = c.Flags().SetAnnotation("template", "IsPrint", []string{"true"})
 		_ = c.MarkFlagFilename("template")
 	}
 	if f.AllowMissingKeys != nil {
 		c.Flags().BoolVar(f.AllowMissingKeys, "allow-missing-template-keys", *f.AllowMissingKeys, "If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.")
+		_ = c.Flags().SetAnnotation("allow-missing-template-keys", "IsPrint", []string{"true"})
 	}
 }
 


### PR DESCRIPTION
Automatically generate and push the generated `.yml` files to the documentation repository on release.