### PR TITLE
[DEX-90] Improve help and error messages for json-nd imports

### DIFF
--- a/pkg/cmd/objects/import/import.go
+++ b/pkg/cmd/objects/import/import.go
@@ -44,7 +44,7 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:             "Import objects to the specified indice",
 		Long: heredoc.Doc(`
 			Import objects to the specified indice from a file / the standard input.
-			The file must contains one JSON object per line (newline delimited JSON objects - ndjson format).
+			The file must contains one single JSON object per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
 			# Import objects from the "data.ndjson" file to the "TEST_PRODUCTS_1" index
@@ -52,6 +52,9 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 
 			# Import objects from the standard input to the "TEST_PRODUCTS_1" index
 			$ cat data.ndjson | algolia objects import TEST_PRODUCTS_1 -F -
+
+			# Browse the objects in the "TEST_PRODUCTS_1" index and import them to the "TEST_PRODUCTS_2" index
+			$ algolia objects browse TEST_PRODUCTS_1 | algolia objects import TEST_PRODUCTS_2 -F -
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Index = args[0]
@@ -99,6 +102,7 @@ func runImportCmd(opts *ImportOptions) error {
 
 		var obj interface{}
 		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			err := fmt.Errorf("failed to parse JSON object on line %d: %s", count, err)
 			return err
 		}
 

--- a/pkg/cmd/rules/import/import.go
+++ b/pkg/cmd/rules/import/import.go
@@ -41,7 +41,7 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:             "Import rules to the specified index",
 		Long: heredoc.Doc(`
 			Import rules to the specified index.
-			The file must contains one JSON rule per line (newline delimited JSON objects - ndjson format).
+			The file must contains one JSON rule per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
 			# Import rules from the "rules.ndjson" file to the "TEST_PRODUCTS_1" index
@@ -49,6 +49,9 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 
 			# Import rules from the standard input to the "TEST_PRODUCTS_1" index
 			$ cat rules.ndjson | algolia rules import TEST_PRODUCTS_1 -F -
+
+			# Browse the rules in the "TEST_PRODUCTS_1" index and import them to the "TEST_PRODUCTS_2" index
+			$ algolia rules browse TEST_PRODUCTS_2 | algolia rules import TEST_PRODUCTS_2 -F -
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]
@@ -93,6 +96,7 @@ func runImportCmd(opts *ImportOptions) error {
 
 		var rule search.Rule
 		if err := json.Unmarshal([]byte(line), &rule); err != nil {
+			err := fmt.Errorf("failed to parse JSON rule on line %d: %s", count, err)
 			return err
 		}
 

--- a/pkg/cmd/rules/import/import_test.go
+++ b/pkg/cmd/rules/import/import_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func Test_runExportCmd(t *testing.T) {
-
 	tmpFile := filepath.Join(t.TempDir(), "rules.json")
 	err := ioutil.WriteFile(tmpFile, []byte("{\"objectID\":\"test\"}"), 0600)
 	require.NoError(t, err)
@@ -25,6 +24,7 @@ func Test_runExportCmd(t *testing.T) {
 		cli     string
 		stdin   string
 		wantOut string
+		wantErr string
 	}{
 		{
 			name:    "from stdin",
@@ -37,19 +37,28 @@ func Test_runExportCmd(t *testing.T) {
 			cli:     fmt.Sprintf("foo -F '%s'", tmpFile),
 			wantOut: "✓ Successfully imported 1 rules to foo\n",
 		},
+		{
+			name:    "from stdin with invalid JSON",
+			cli:     "foo -F -",
+			stdin:   `{"objectID", "test"},`,
+			wantErr: "failed to parse JSON rule on line 0: invalid character ',' after object key",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := httpmock.Registry{}
-			r.Register(httpmock.REST("POST", "1/indexes/foo/rules/batch"), httpmock.JSONResponse(search.UpdateTaskRes{}))
+			if tt.wantErr == "" {
+				r.Register(httpmock.REST("POST", "1/indexes/foo/rules/batch"), httpmock.JSONResponse(search.UpdateTaskRes{}))
+			}
 			defer r.Verify(t)
 
 			f, out := test.NewFactory(true, &r, nil, tt.stdin)
 			cmd := NewImportCmd(f)
 			out, err := test.Execute(cmd, tt.cli, out)
 			if err != nil {
-				t.Fatal(err)
+				assert.EqualError(t, err, tt.wantErr)
+				return
 			}
 
 			assert.Equal(t, tt.wantOut, out.String())

--- a/pkg/cmd/synonyms/import/import.go
+++ b/pkg/cmd/synonyms/import/import.go
@@ -41,7 +41,7 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:             "Import synonyms to the indice",
 		Long: heredoc.Doc(`
 			Import synonyms to the provided indice.
-			The file must contains one JSON synonym per line (newline delimited JSON objects - ndjson format).
+			The file must contains one single JSON synonym per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
 			# Import synonyms from the "synonyms.ndjson" file to the "TEST_PRODUCTS_1" index
@@ -49,6 +49,9 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 
 			# Import objects from the standard input to the "TEST_PRODUCTS_1" index
 			$ cat synonyms.ndjson | algolia synonyms import TEST_PRODUCTS_1 -F -
+
+			# Browse the synonyms in the "TEST_PRODUCTS_1" index and import them to the "TEST_PRODUCTS_2" index
+			$ algolia synonyms browse TEST_PRODUCTS_1 | algolia synonyms import TEST_PRODUCTS_2 -F -
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Index = args[0]
@@ -96,6 +99,7 @@ func runImportCmd(opts *ImportOptions) error {
 
 		// Unmarshal as map[string]interface{} to get the type of the synonym
 		if err := json.Unmarshal(lineB, &rawSynonym); err != nil {
+			err := fmt.Errorf("failed to parse JSON synonym on line %d: %s", count, err)
 			return err
 		}
 		typeString := rawSynonym["type"].(string)


### PR DESCRIPTION
Small improvements for the commands expecting a `json-nd` input (`synonyms`, `objects` and `rules` commands):
- Adding a link to the json-nd specs in the help message:
> The file must contains one single JSON object per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
- Better error message when parsing issues are happening, with the line number:
> failed to parse JSON object on line 0: invalid character ',' after object key