### PR TITLE
[DEX-107] Add objects,synonyms,rules delete commands

### DIFF
--- a/pkg/cmd/objects/delete/delete.go
+++ b/pkg/cmd/objects/delete/delete.go
@@ -1,0 +1,108 @@
+package delete
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/prompt"
+	"github.com/algolia/cli/pkg/utils"
+)
+
+type DeleteOptions struct {
+	Config config.IConfig
+	IO     *iostreams.IOStreams
+
+	SearchClient func() (*search.Client, error)
+
+	Indice    string
+	ObjectIDs []string
+
+	DoConfirm bool
+}
+
+// NewDeleteCmd creates and returns a delete command for index objects
+func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Command {
+	var confirm bool
+
+	opts := &DeleteOptions{
+		IO:           f.IOStreams,
+		Config:       f.Config,
+		SearchClient: f.SearchClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:               "delete <index> --object-ids <object-ids> --confirm",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
+		Short:             "Delete objects from an index",
+		Long: heredoc.Doc(`
+			This command deletes the objects from the specified index.
+		`),
+		Example: heredoc.Doc(`
+			# Delete one single object with the ID "1" from the "TEST_PRODUCTS_1" index
+			$ algolia objects delete TEST_PRODUCTS_1 --object-ids 1
+
+			# Delete multiple objects with the IDs "1" and "2" from the "TEST_PRODUCTS_1" index
+			$ algolia objects delete TEST_PRODUCTS_1 --object-ids 1,2
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Indice = args[0]
+			if !confirm {
+				if !opts.IO.CanPrompt() {
+					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
+				}
+				opts.DoConfirm = true
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return runDeleteCmd(opts)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&opts.ObjectIDs, "object-ids", "", nil, "Object IDs to delete")
+	_ = cmd.MarkFlagRequired("object-ids")
+
+	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "skip confirmation prompt")
+
+	return cmd
+}
+
+func runDeleteCmd(opts *DeleteOptions) error {
+	client, err := opts.SearchClient()
+	if err != nil {
+		return err
+	}
+
+	indice := client.InitIndex(opts.Indice)
+	if opts.DoConfirm {
+		var confirmed bool
+		err = prompt.Confirm(fmt.Sprintf("Delete the %s from %s?", utils.Pluralize(len(opts.ObjectIDs), "object"), opts.Indice), &confirmed)
+		if err != nil {
+			return fmt.Errorf("failed to prompt: %w", err)
+		}
+		if !confirmed {
+			return nil
+		}
+	}
+
+	_, err = indice.DeleteObjects(opts.ObjectIDs)
+	if err != nil {
+		return err
+	}
+
+	cs := opts.IO.ColorScheme()
+	if opts.IO.IsStdoutTTY() {
+		fmt.Fprintf(opts.IO.Out, "%s Successfully deleted %s from %s\n", cs.SuccessIcon(), utils.Pluralize(len(opts.ObjectIDs), "object"), opts.Indice)
+	}
+
+	return nil
+}

--- a/pkg/cmd/objects/delete/delete_test.go
+++ b/pkg/cmd/objects/delete/delete_test.go
@@ -1,0 +1,170 @@
+package delete
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/test"
+)
+
+func TestNewDeleteCmd(t *testing.T) {
+	tests := []struct {
+		name      string
+		tty       bool
+		cli       string
+		wantsErr  bool
+		wantsOpts DeleteOptions
+	}{
+		{
+			name:     "no --confirm without tty",
+			cli:      "foo --object-ids 1",
+			tty:      false,
+			wantsErr: true,
+		},
+		{
+			name:     "--confirm without tty",
+			cli:      "foo --object-ids 1 --confirm",
+			tty:      true,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: false,
+				Indice:    "foo",
+				ObjectIDs: []string{
+					"1",
+				},
+			},
+		},
+		{
+			name:     "no --confirm with tty",
+			cli:      "foo --object-ids 1",
+			tty:      true,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: true,
+				Indice:    "foo",
+				ObjectIDs: []string{
+					"1",
+				},
+			},
+		},
+		{
+			name:     "multiple --object-ids",
+			cli:      "foo --object-ids 1,2 --confirm",
+			tty:      false,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: false,
+				Indice:    "foo",
+				ObjectIDs: []string{
+					"1",
+					"2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, stdout, stderr := iostreams.Test()
+			if tt.tty {
+				io.SetStdinTTY(tt.tty)
+				io.SetStdoutTTY(tt.tty)
+			}
+
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+
+			var opts *DeleteOptions
+			cmd := NewDeleteCmd(f, func(o *DeleteOptions) error {
+				opts = o
+				return nil
+			})
+
+			args, err := shlex.Split(tt.cli)
+			require.NoError(t, err)
+			cmd.SetArgs(args)
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, "", stdout.String())
+			assert.Equal(t, "", stderr.String())
+
+			assert.Equal(t, tt.wantsOpts.Indice, opts.Indice)
+			assert.Equal(t, tt.wantsOpts.ObjectIDs, opts.ObjectIDs)
+			assert.Equal(t, tt.wantsOpts.DoConfirm, opts.DoConfirm)
+		})
+	}
+}
+
+func Test_runDeleteCmd(t *testing.T) {
+	tests := []struct {
+		name      string
+		cli       string
+		indice    string
+		objectIDs []string
+		isTTY     bool
+		wantOut   string
+	}{
+		{
+			name:   "single object-id, no TTY",
+			cli:    "foo --object-ids 1 --confirm",
+			indice: "foo",
+			objectIDs: []string{
+				"1",
+			},
+			isTTY:   false,
+			wantOut: "",
+		},
+		{
+			name:   "single object-id, TTY",
+			cli:    "foo --object-ids 1 --confirm",
+			indice: "foo",
+			objectIDs: []string{
+				"1",
+			},
+			isTTY:   true,
+			wantOut: "✓ Successfully deleted 1 object from foo\n",
+		},
+		{
+			name:   "multiple object-ids, TTY",
+			cli:    "foo --object-ids 1,2 --confirm",
+			indice: "foo",
+			objectIDs: []string{
+				"1",
+				"2",
+			},
+			isTTY:   true,
+			wantOut: "✓ Successfully deleted 2 objects from foo\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httpmock.Registry{}
+			r.Register(httpmock.REST("POST", fmt.Sprintf("1/indexes/%s/batch", tt.indice)), httpmock.JSONResponse(search.BatchRes{}))
+
+			f, out := test.NewFactory(tt.isTTY, &r, nil, "")
+			cmd := NewDeleteCmd(f, nil)
+			out, err := test.Execute(cmd, tt.cli, out)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tt.wantOut, out.String())
+		})
+	}
+}

--- a/pkg/cmd/rules/delete/delete.go
+++ b/pkg/cmd/rules/delete/delete.go
@@ -1,0 +1,114 @@
+package delete
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/prompt"
+	"github.com/algolia/cli/pkg/utils"
+)
+
+type DeleteOptions struct {
+	Config config.IConfig
+	IO     *iostreams.IOStreams
+
+	SearchClient func() (*search.Client, error)
+
+	Indice            string
+	RuleIDs           []string
+	ForwardToReplicas bool
+
+	DoConfirm bool
+}
+
+// NewDeleteCmd creates and returns a delete command for index rules
+func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Command {
+	var confirm bool
+
+	opts := &DeleteOptions{
+		IO:           f.IOStreams,
+		Config:       f.Config,
+		SearchClient: f.SearchClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:               "delete <index> --rule-ids <rule-ids> --confirm",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
+		Short:             "Delete rules from an index",
+		Long: heredoc.Doc(`
+			This command deletes the rules from the specified index.
+		`),
+		Example: heredoc.Doc(`
+			# Delete one single rule with the ID "1" from the "TEST_PRODUCTS_1" index
+			$ algolia rules delete TEST_PRODUCTS_1 --rule-ids 1
+
+			# Delete multiple rules with the IDs "1" and "2" from the "TEST_PRODUCTS_1" index
+			$ algolia rules delete TEST_PRODUCTS_1 --rule-ids 1,2
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Indice = args[0]
+			if !confirm {
+				if !opts.IO.CanPrompt() {
+					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
+				}
+				opts.DoConfirm = true
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return runDeleteCmd(opts)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&opts.RuleIDs, "rule-ids", "", nil, "Rule IDs to delete")
+	_ = cmd.MarkFlagRequired("rule-ids")
+	cmd.Flags().BoolVar(&opts.ForwardToReplicas, "forward-to-replicas", false, "Forward the delete request to the replicas")
+
+	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "skip confirmation prompt")
+
+	return cmd
+}
+
+func runDeleteCmd(opts *DeleteOptions) error {
+	client, err := opts.SearchClient()
+	if err != nil {
+		return err
+	}
+
+	indice := client.InitIndex(opts.Indice)
+	if opts.DoConfirm {
+		var confirmed bool
+		err = prompt.Confirm(fmt.Sprintf("Delete the %s from %s?", utils.Pluralize(len(opts.RuleIDs), "rule"), opts.Indice), &confirmed)
+		if err != nil {
+			return fmt.Errorf("failed to prompt: %w", err)
+		}
+		if !confirmed {
+			return nil
+		}
+	}
+
+	for _, ruleID := range opts.RuleIDs {
+		_, err = indice.DeleteRule(ruleID, opt.ForwardToReplicas(opts.ForwardToReplicas))
+		if err != nil {
+			err = fmt.Errorf("failed to delete rule %s: %w", ruleID, err)
+			return err
+		}
+	}
+
+	cs := opts.IO.ColorScheme()
+	if opts.IO.IsStdoutTTY() {
+		fmt.Fprintf(opts.IO.Out, "%s Successfully deleted %s from %s\n", cs.SuccessIcon(), utils.Pluralize(len(opts.RuleIDs), "rule"), opts.Indice)
+	}
+
+	return nil
+}

--- a/pkg/cmd/rules/delete/delete_test.go
+++ b/pkg/cmd/rules/delete/delete_test.go
@@ -1,0 +1,191 @@
+package delete
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/test"
+)
+
+func TestNewDeleteCmd(t *testing.T) {
+	tests := []struct {
+		name      string
+		tty       bool
+		cli       string
+		wantsErr  bool
+		wantsOpts DeleteOptions
+	}{
+		{
+			name:     "no --confirm without tty",
+			cli:      "foo --rule-ids 1",
+			tty:      false,
+			wantsErr: true,
+		},
+		{
+			name:     "--confirm without tty",
+			cli:      "foo --rule-ids 1 --confirm",
+			tty:      true,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: false,
+				Indice:    "foo",
+				RuleIDs: []string{
+					"1",
+				},
+				ForwardToReplicas: false,
+			},
+		},
+		{
+			name:     "no --confirm with tty",
+			cli:      "foo --rule-ids 1",
+			tty:      true,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: true,
+				Indice:    "foo",
+				RuleIDs: []string{
+					"1",
+				},
+				ForwardToReplicas: false,
+			},
+		},
+		{
+			name:     "multiple --rule-ids",
+			cli:      "foo --rule-ids 1,2 --confirm",
+			tty:      false,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: false,
+				Indice:    "foo",
+				RuleIDs: []string{
+					"1",
+					"2",
+				},
+				ForwardToReplicas: false,
+			},
+		},
+		{
+			name:     "multiple --rule-ids, forward to replicas",
+			cli:      "foo --rule-ids 1,2 --confirm --forward-to-replicas",
+			tty:      false,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: false,
+				Indice:    "foo",
+				RuleIDs: []string{
+					"1",
+					"2",
+				},
+				ForwardToReplicas: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, stdout, stderr := iostreams.Test()
+			if tt.tty {
+				io.SetStdinTTY(tt.tty)
+				io.SetStdoutTTY(tt.tty)
+			}
+
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+
+			var opts *DeleteOptions
+			cmd := NewDeleteCmd(f, func(o *DeleteOptions) error {
+				opts = o
+				return nil
+			})
+
+			args, err := shlex.Split(tt.cli)
+			require.NoError(t, err)
+			cmd.SetArgs(args)
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, "", stdout.String())
+			assert.Equal(t, "", stderr.String())
+
+			assert.Equal(t, tt.wantsOpts.Indice, opts.Indice)
+			assert.Equal(t, tt.wantsOpts.RuleIDs, opts.RuleIDs)
+			assert.Equal(t, tt.wantsOpts.ForwardToReplicas, opts.ForwardToReplicas)
+			assert.Equal(t, tt.wantsOpts.DoConfirm, opts.DoConfirm)
+		})
+	}
+}
+
+func Test_runDeleteCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		indice  string
+		ruleIDs []string
+		isTTY   bool
+		wantOut string
+	}{
+		{
+			name:   "single rule-id, no TTY",
+			cli:    "foo --rule-ids 1 --confirm",
+			indice: "foo",
+			ruleIDs: []string{
+				"1",
+			},
+			isTTY:   false,
+			wantOut: "",
+		},
+		{
+			name:   "single rule-id, TTY",
+			cli:    "foo --rule-ids 1 --confirm",
+			indice: "foo",
+			ruleIDs: []string{
+				"1",
+			},
+			isTTY:   true,
+			wantOut: "✓ Successfully deleted 1 rule from foo\n",
+		},
+		{
+			name:   "multiple rule-ids, TTY",
+			cli:    "foo --rule-ids 1,2 --confirm",
+			indice: "foo",
+			ruleIDs: []string{
+				"1",
+				"2",
+			},
+			isTTY:   true,
+			wantOut: "✓ Successfully deleted 2 rules from foo\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httpmock.Registry{}
+			for _, id := range tt.ruleIDs {
+				r.Register(httpmock.REST("DELETE", fmt.Sprintf("1/indexes/%s/rules/%s", tt.indice, id)), httpmock.JSONResponse(search.DeleteTaskRes{}))
+			}
+
+			f, out := test.NewFactory(tt.isTTY, &r, nil, "")
+			cmd := NewDeleteCmd(f, nil)
+			out, err := test.Execute(cmd, tt.cli, out)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tt.wantOut, out.String())
+		})
+	}
+}

--- a/pkg/cmd/synonyms/delete/delete.go
+++ b/pkg/cmd/synonyms/delete/delete.go
@@ -1,0 +1,114 @@
+package delete
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/prompt"
+	"github.com/algolia/cli/pkg/utils"
+)
+
+type DeleteOptions struct {
+	Config config.IConfig
+	IO     *iostreams.IOStreams
+
+	SearchClient func() (*search.Client, error)
+
+	Indice            string
+	SynonymIDs        []string
+	ForwardToReplicas bool
+
+	DoConfirm bool
+}
+
+// NewDeleteCmd creates and returns a delete command for index synonyms
+func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Command {
+	var confirm bool
+
+	opts := &DeleteOptions{
+		IO:           f.IOStreams,
+		Config:       f.Config,
+		SearchClient: f.SearchClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:               "delete <index> --synonyms <synonym-ids> --confirm",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
+		Short:             "Delete synonyms from an index",
+		Long: heredoc.Doc(`
+			This command deletes the synonyms from the specified index.
+		`),
+		Example: heredoc.Doc(`
+			# Delete one single synonym with the ID "1" from the "TEST_PRODUCTS_1" index
+			$ algolia synonyms delete TEST_PRODUCTS_1 --synonym-ids 1
+
+			# Delete multiple synonyms with the IDs "1" and "2" from the "TEST_PRODUCTS_1" index
+			$ algolia synonyms delete TEST_PRODUCTS_1 --synonym-ids 1 2
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Indice = args[0]
+			if !confirm {
+				if !opts.IO.CanPrompt() {
+					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
+				}
+				opts.DoConfirm = true
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return runDeleteCmd(opts)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&opts.SynonymIDs, "synonym-ids", "", nil, "Synonym IDs to delete")
+	_ = cmd.MarkFlagRequired("synonym-ids")
+	cmd.Flags().BoolVar(&opts.ForwardToReplicas, "forward-to-replicas", false, "Forward the delete request to the replicas")
+
+	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "skip confirmation prompt")
+
+	return cmd
+}
+
+func runDeleteCmd(opts *DeleteOptions) error {
+	client, err := opts.SearchClient()
+	if err != nil {
+		return err
+	}
+
+	indice := client.InitIndex(opts.Indice)
+	if opts.DoConfirm {
+		var confirmed bool
+		err = prompt.Confirm(fmt.Sprintf("Delete the %s from %s?", utils.Pluralize(len(opts.SynonymIDs), "synonym"), opts.Indice), &confirmed)
+		if err != nil {
+			return fmt.Errorf("failed to prompt: %w", err)
+		}
+		if !confirmed {
+			return nil
+		}
+	}
+
+	for _, synonymID := range opts.SynonymIDs {
+		_, err = indice.DeleteSynonym(synonymID, opt.ForwardToReplicas(opts.ForwardToReplicas))
+		if err != nil {
+			err = fmt.Errorf("failed to delete synonym %s: %w", synonymID, err)
+			return err
+		}
+	}
+
+	cs := opts.IO.ColorScheme()
+	if opts.IO.IsStdoutTTY() {
+		fmt.Fprintf(opts.IO.Out, "%s Successfully deleted %s from %s\n", cs.SuccessIcon(), utils.Pluralize(len(opts.SynonymIDs), "synonym"), opts.Indice)
+	}
+
+	return nil
+}

--- a/pkg/cmd/synonyms/delete/delete_test.go
+++ b/pkg/cmd/synonyms/delete/delete_test.go
@@ -1,0 +1,191 @@
+package delete
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/test"
+)
+
+func TestNewDeleteCmd(t *testing.T) {
+	tests := []struct {
+		name      string
+		tty       bool
+		cli       string
+		wantsErr  bool
+		wantsOpts DeleteOptions
+	}{
+		{
+			name:     "no --confirm without tty",
+			cli:      "foo --synonym-ids 1",
+			tty:      false,
+			wantsErr: true,
+		},
+		{
+			name:     "--confirm without tty",
+			cli:      "foo --synonym-ids 1 --confirm",
+			tty:      true,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: false,
+				Indice:    "foo",
+				SynonymIDs: []string{
+					"1",
+				},
+				ForwardToReplicas: false,
+			},
+		},
+		{
+			name:     "no --confirm with tty",
+			cli:      "foo --synonym-ids 1",
+			tty:      true,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: true,
+				Indice:    "foo",
+				SynonymIDs: []string{
+					"1",
+				},
+				ForwardToReplicas: false,
+			},
+		},
+		{
+			name:     "multiple --synonym-ids",
+			cli:      "foo --synonym-ids 1,2 --confirm",
+			tty:      false,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: false,
+				Indice:    "foo",
+				SynonymIDs: []string{
+					"1",
+					"2",
+				},
+				ForwardToReplicas: false,
+			},
+		},
+		{
+			name:     "multiple --synonym-ids, forward to replicas",
+			cli:      "foo --synonym-ids 1,2 --confirm --forward-to-replicas",
+			tty:      false,
+			wantsErr: false,
+			wantsOpts: DeleteOptions{
+				DoConfirm: false,
+				Indice:    "foo",
+				SynonymIDs: []string{
+					"1",
+					"2",
+				},
+				ForwardToReplicas: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, stdout, stderr := iostreams.Test()
+			if tt.tty {
+				io.SetStdinTTY(tt.tty)
+				io.SetStdoutTTY(tt.tty)
+			}
+
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+
+			var opts *DeleteOptions
+			cmd := NewDeleteCmd(f, func(o *DeleteOptions) error {
+				opts = o
+				return nil
+			})
+
+			args, err := shlex.Split(tt.cli)
+			require.NoError(t, err)
+			cmd.SetArgs(args)
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, "", stdout.String())
+			assert.Equal(t, "", stderr.String())
+
+			assert.Equal(t, tt.wantsOpts.Indice, opts.Indice)
+			assert.Equal(t, tt.wantsOpts.SynonymIDs, opts.SynonymIDs)
+			assert.Equal(t, tt.wantsOpts.ForwardToReplicas, opts.ForwardToReplicas)
+			assert.Equal(t, tt.wantsOpts.DoConfirm, opts.DoConfirm)
+		})
+	}
+}
+
+func Test_runDeleteCmd(t *testing.T) {
+	tests := []struct {
+		name       string
+		cli        string
+		indice     string
+		synonymIDs []string
+		isTTY      bool
+		wantOut    string
+	}{
+		{
+			name:   "single synonym-id, no TTY",
+			cli:    "foo --synonym-ids 1 --confirm",
+			indice: "foo",
+			synonymIDs: []string{
+				"1",
+			},
+			isTTY:   false,
+			wantOut: "",
+		},
+		{
+			name:   "single synonym-id, TTY",
+			cli:    "foo --synonym-ids 1 --confirm",
+			indice: "foo",
+			synonymIDs: []string{
+				"1",
+			},
+			isTTY:   true,
+			wantOut: "✓ Successfully deleted 1 synonym from foo\n",
+		},
+		{
+			name:   "multiple synonym-ids, TTY",
+			cli:    "foo --synonym-ids 1,2 --confirm",
+			indice: "foo",
+			synonymIDs: []string{
+				"1",
+				"2",
+			},
+			isTTY:   true,
+			wantOut: "✓ Successfully deleted 2 synonyms from foo\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httpmock.Registry{}
+			for _, id := range tt.synonymIDs {
+				r.Register(httpmock.REST("DELETE", fmt.Sprintf("1/indexes/%s/synonyms/%s", tt.indice, id)), httpmock.JSONResponse(search.DeleteTaskRes{}))
+			}
+
+			f, out := test.NewFactory(tt.isTTY, &r, nil, "")
+			cmd := NewDeleteCmd(f, nil)
+			out, err := test.Execute(cmd, tt.cli, out)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tt.wantOut, out.String())
+		})
+	}
+}


### PR DESCRIPTION
Add the `objects delete`, `synonyms delete` and `rules delete` commands.

Example usage:
```
$ algolia objects delete TEST_PRODUCTS_1 --object-ids 1
```