### PR TITLE
fix(config) Remove profile without default

### DIFF
--- a/pkg/cmd/profile/remove/remove.go
+++ b/pkg/cmd/profile/remove/remove.go
@@ -18,7 +18,8 @@ type RemoveOptions struct {
 	config config.IConfig
 	IO     *iostreams.IOStreams
 
-	Profile string
+	Profile        string
+	DefaultProfile string
 
 	DoConfirm bool
 }
@@ -44,7 +45,14 @@ func NewRemoveCmd(f *cmdutil.Factory, runF func(*RemoveOptions) error) *cobra.Co
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Profile = args[0]
-			if !confirm && opts.Profile == opts.config.Default().Name {
+
+			if opts.config.Default() != nil {
+				opts.DefaultProfile = opts.config.Default().Name
+			} else {
+				opts.DefaultProfile = ""
+			}
+
+			if !confirm && opts.Profile == opts.DefaultProfile {
 				if !opts.IO.CanPrompt() {
 					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
 				}
@@ -89,7 +97,7 @@ func runRemoveCmd(opts *RemoveOptions) error {
 	cs := opts.IO.ColorScheme()
 	if opts.IO.IsStdoutTTY() {
 		extra := "."
-		if opts.config.Default().Name == opts.Profile {
+		if opts.DefaultProfile == opts.Profile {
 			extra = ". Set a new default profile with 'algolia profile setdefault'."
 		}
 		if len(opts.config.ConfiguredProfiles()) == 0 {

--- a/pkg/cmd/profile/remove/remove_test.go
+++ b/pkg/cmd/profile/remove/remove_test.go
@@ -115,10 +115,16 @@ func Test_runRemoveCmd(t *testing.T) {
 			wantsErr: "the specified profile does not exist: 'bar'",
 		},
 		{
-			name:     "only one profile",
+			name:     "only one profile (default)",
 			cli:      "default --confirm",
 			profiles: map[string]bool{"default": true},
 			wantOut:  "✓ 'default' removed successfully. Add a profile with 'algolia profile add'.\n",
+		},
+		{
+			name:     "only one profile (non-default)",
+			cli:      "foo --confirm",
+			profiles: map[string]bool{"foo": false},
+			wantOut:  "✓ 'foo' removed successfully. Add a profile with 'algolia profile add'.\n",
 		},
 	}
 


### PR DESCRIPTION
Bug fix for the removal of a profile, when no existing default profile are set. The `opts.config.Default()` would be then `nil`, and accessing the `Name` would fire a nil pointer error.

We are fixing this by checking / storing the default profile early, and by storing the name in the command options.