### PR TITLE
feat(search): add supports for extensions flags

### DIFF
--- a/api/specs/search.yml
+++ b/api/specs/search.yml
@@ -257,6 +257,8 @@ components:
             - Filtering
         facetFilters:
           $ref: '#/components/schemas/facetFilters'
+        extensions:
+          $ref: '#/components/schemas/extensions'
         optionalFilters:
           $ref: '#/components/schemas/optionalFilters'
         numericFilters:
@@ -624,6 +626,12 @@ components:
       properties:
         facetOrdering:
           $ref: '#/components/schemas/facetOrdering'
+      x-categories:
+        - Advanced
+    extensions:
+      description: parameters forwarded to search extensions
+      type: object
+      additionalProperties: false
       x-categories:
         - Advanced
     indexSettingsAsSearchParams:

--- a/pkg/cmd/search/search.go
+++ b/pkg/cmd/search/search.go
@@ -85,6 +85,7 @@ func runSearchCmd(opts *SearchOptions) error {
 	} else {
 		delete(opts.SearchParams, "query")
 	}
+	// opts.SearchParams["extensions"] = map[string]any{"queryCategorization": map[string]bool{"enabled": true, "enableCategoriesRetrieval": false}}
 	res, err := indice.Search(query, opt.ExtraOptions(opts.SearchParams))
 	if err != nil {
 		opts.IO.StopProgressIndicator()

--- a/pkg/cmdutil/spec_flags.go
+++ b/pkg/cmdutil/spec_flags.go
@@ -92,6 +92,7 @@ var SearchParamsObject = []string{
 	"enableReRanking",
 	"enableRules",
 	"exactOnSingleWordQuery",
+	"extensions",
 	"facetFilters",
 	"facetingAfterDistinct",
 	"facets",
@@ -322,6 +323,9 @@ func AddSearchParamsObjectFlags(cmd *cobra.Command) {
 	cmd.Flags().SetAnnotation("enableRules", "Categories", []string{"Rules"})
 	cmd.Flags().String("exactOnSingleWordQuery", "attribute", heredoc.Doc(`Controls how the exact ranking criterion is computed when the query contains only one word. One of: (attribute, none, word).`))
 	cmd.Flags().SetAnnotation("exactOnSingleWordQuery", "Categories", []string{"Query strategy"})
+	extensions := NewJSONVar([]string{}...)
+	cmd.Flags().Var(extensions, "extensions", heredoc.Doc(`parameters forwarded to search extensions`))
+	cmd.Flags().SetAnnotation("extensions", "Categories", []string{"Advanced"})
 	facetFilters := NewJSONVar([]string{"array", "array"}...)
 	cmd.Flags().Var(facetFilters, "facetFilters", heredoc.Doc(`Filter hits by facet value.`))
 	cmd.Flags().SetAnnotation("facetFilters", "Categories", []string{"Filtering"})


### PR DESCRIPTION
## What

* Support `extensions` search parameters

## Why

* Allow testing query-categorization
