### PR TITLE
fix: broken link to CLI Docs

### DIFF
--- a/pkg/cmd/open/open.go
+++ b/pkg/cmd/open/open.go
@@ -21,7 +21,7 @@ var nameURLmap = map[string]string{
 	"codex":     "https://www.algolia.com/developers/code-exchange/",
 	"devhub":    "https://www.algolia.com/developers/",
 	"docs":      "https://algolia.com/doc/",
-	"cli-docs":  "https://algolia.com/doc/tools/cli/getstarted/",
+	"cli-docs":  "https://algolia.com/doc/tools/cli/get-started/overview/",
 	"cli-repo":  "https://github.com/algolia/cli",
 }
 


### PR DESCRIPTION
This PR fixes the link to the CLI Docs, so that `algolia open cli-docs` works properly.