### PR TITLE
fix(profile): Reload config before setting the default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -148,6 +148,14 @@ func (c *Config) RemoveProfile(name string) error {
 // SetDefaultProfile set the default profile
 func (c *Config) SetDefaultProfile(name string) error {
 	runtimeViper := viper.GetViper()
+
+	// Below is necessary if the config file was just created
+	runtimeViper.SetConfigType("toml")
+	err := runtimeViper.ReadInConfig()
+	if err != nil {
+		return err
+	}
+
 	configs := runtimeViper.AllSettings()
 
 	found := false


### PR DESCRIPTION
Fixing the behaviour of the `SetDefaultProfile` when dealing with a non-existent (at least in memory) config file.
Fix #68 