### PR TITLE
[DEX-334] feat: algolia objects update

### DIFF
--- a/objects-update.json
+++ b/objects-update.json
@@ -1,6 +1,0 @@
-[
-  {
-    "objectID": "321",
-    "property3": 1
-  }
-]

--- a/objects-update.json
+++ b/objects-update.json
@@ -1,0 +1,6 @@
+[
+  {
+    "objectID": "321",
+    "property3": 1
+  }
+]

--- a/pkg/cmd/objects/objects.go
+++ b/pkg/cmd/objects/objects.go
@@ -6,6 +6,7 @@ import (
 	"github.com/algolia/cli/pkg/cmd/objects/browse"
 	"github.com/algolia/cli/pkg/cmd/objects/delete"
 	importObjects "github.com/algolia/cli/pkg/cmd/objects/import"
+	updateObjects "github.com/algolia/cli/pkg/cmd/objects/update"
 	"github.com/algolia/cli/pkg/cmdutil"
 )
 
@@ -19,6 +20,7 @@ func NewObjectsCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(browse.NewBrowseCmd(f))
 	cmd.AddCommand(importObjects.NewImportCmd(f))
 	cmd.AddCommand(delete.NewDeleteCmd(f, nil))
+	cmd.AddCommand(updateObjects.NewUpdateCmd(f, nil))
 
 	return cmd
 }

--- a/pkg/cmd/objects/update/object.go
+++ b/pkg/cmd/objects/update/object.go
@@ -1,0 +1,78 @@
+package updateObjects
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/cli/pkg/utils"
+)
+
+type ObjectsToUpdate []map[string]interface{}
+
+func (o *ObjectsToUpdate) UnmarshalJSON(data []byte) error {
+	var rawObjectsToUpdate []map[string]interface{}
+	err := json.Unmarshal(data, &rawObjectsToUpdate)
+	if err != nil {
+		return err
+	}
+
+	var objectsToUpdate ObjectsToUpdate
+	for objectIndex := range rawObjectsToUpdate {
+		rawObject := rawObjectsToUpdate[objectIndex]
+		objectToUpdate := map[string]interface{}{}
+
+		for name, rawValue := range rawObject {
+			valueString, isValueString := rawValue.(string)
+			if name != "objectID" {
+				_, isValueBool := rawValue.(bool)
+				_, isValueFloat := rawValue.(float64)
+
+				if isValueBool || isValueFloat || isValueString {
+					objectToUpdate[name] = rawValue
+				} else {
+					mapValue, isMap := rawValue.(map[string]interface{})
+					if !isMap {
+						return fmt.Errorf("Object value/operation not recognized for object %d", objectIndex+1)
+					}
+					mapValueString, isMapValueString := mapValue["value"].(string)
+					// JSON unmarshal numbers to float64 by default
+					mapValueFloat, isMapValueFloat := mapValue["value"].(float64)
+					mapValueInt := int(mapValueFloat)
+
+					operationString, ok := mapValue["operation"].(string)
+					if !ok {
+						return fmt.Errorf("Invalid operation for object %d", objectIndex+1)
+					}
+					isOperationValid := isOperationTypeValid(operationString)
+					if !isOperationValid {
+						return fmt.Errorf("Invalid operation type for object %d", objectIndex+1)
+					}
+
+					var operationValue interface{}
+					if isMapValueFloat {
+						operationValue = mapValueInt
+					} else if isMapValueString {
+						operationValue = mapValueString
+					}
+					objectToUpdate[name] = search.PartialUpdateOperation{
+						Operation: operationString,
+						Value:     operationValue,
+					}
+				}
+			} else if !isValueString {
+				return fmt.Errorf("Error at object %d: objectID should be a string", objectIndex+1)
+			} else {
+				objectToUpdate["objectID"] = valueString
+			}
+		}
+		objectsToUpdate = append(objectsToUpdate, objectToUpdate)
+	}
+	*o = objectsToUpdate
+	return nil
+}
+
+func isOperationTypeValid(value string) bool {
+	return utils.Contains([]string{"Increment", "Decrement", "Add", "Remove",
+		"AddUnique", "IncrementFrom", "IncrementSet"}, value)
+}

--- a/pkg/cmd/objects/update/object_test.go
+++ b/pkg/cmd/objects/update/object_test.go
@@ -7,6 +7,53 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_ValidateOperation(t *testing.T) {
+	tests := []struct {
+		name       string
+		operation  string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:       "no operation",
+			operation:  "",
+			wantErr:    true,
+			wantErrMsg: "missing operation",
+		},
+		{
+			name:       "invalid operation",
+			operation:  "invalid",
+			wantErr:    true,
+			wantErrMsg: "invalid operation \"invalid\" (valid operations are Increment, Decrement, Add, AddUnique, IncrementSet and IncrementFrom)",
+		},
+	}
+
+	for _, ops := range []string{"Increment", "Decrement", "Add", "AddUnique", "IncrementSet", "IncrementFrom"} {
+		tests = append(tests, struct {
+			name       string
+			operation  string
+			wantErr    bool
+			wantErrMsg string
+		}{
+			name:      ops,
+			operation: ops,
+			wantErr:   false,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateOperation(search.PartialUpdateOperation{Operation: tt.operation})
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantErrMsg, err.Error())
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func Test_Object_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/cmd/objects/update/object_test.go
+++ b/pkg/cmd/objects/update/object_test.go
@@ -1,0 +1,147 @@
+package updateObjects
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name       string
+		json       string
+		wantOut    ObjectsToUpdate
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "ObjectID, name/value",
+			json: `
+				[
+					{
+						"objectID": "23",
+						"property1": "mj"
+					}
+				]`,
+			wantOut: ObjectsToUpdate{
+				{"objectID": "23", "property1": "mj"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ObjectID, name/operation (increment)",
+			json: `
+				[
+					{
+						"objectID": "24",
+						"property2": {
+							"operation": "Increment",
+							"value": 1
+						}
+					}
+				]`,
+			wantOut: ObjectsToUpdate{
+				{
+					"objectID": "24",
+					"property2": search.PartialUpdateOperation{
+						Operation: "Increment",
+						Value:     1,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "No ObjectID",
+			json: `
+				[
+					{
+						"property1": "mj"
+					}
+				]`,
+			wantOut: ObjectsToUpdate{
+				{
+					"property1": "mj",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Wrong operation",
+			json: `
+				[
+					{
+						"objectID": "24",
+						"property2": {
+							"operation": "Unknown",
+							"value": "random"
+						}
+					}
+				]`,
+			wantErr:    true,
+			wantErrMsg: "Invalid operation type for object 1",
+		},
+		{
+			name: "Wrong operation structure",
+			json: `
+				[
+					{
+						"objectID": "24",
+						"property2": {
+							"type": "Unknown",
+							"value": "random"
+						}
+					}
+				]`,
+			wantErr:    true,
+			wantErrMsg: "Invalid operation for object 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objectsToUpdate ObjectsToUpdate
+			err := json.Unmarshal([]byte(tt.json), &objectsToUpdate)
+
+			if err != nil {
+				assert.Equal(t, tt.wantErr, true)
+				assert.EqualError(t, err, tt.wantErrMsg)
+				return
+			}
+
+			assert.EqualValues(t, objectsToUpdate, tt.wantOut)
+		})
+	}
+}
+
+func Test_isOperationTypeValid(t *testing.T) {
+	tests := []struct {
+		name          string
+		operationType string
+		wantOut       bool
+	}{
+		{
+			name:          "Correct operation type",
+			operationType: "Increment",
+			wantOut:       true,
+		},
+		{
+			name:          "Incorrect operation type (lowercase)",
+			operationType: "increment",
+			wantOut:       false,
+		},
+		{
+			name:          "Incorrect operation type",
+			operationType: "Unknown",
+			wantOut:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantOut, isOperationTypeValid(tt.operationType))
+		})
+	}
+}

--- a/pkg/cmd/objects/update/object_test.go
+++ b/pkg/cmd/objects/update/object_test.go
@@ -1,147 +1,84 @@
-package updateObjects
+package update
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_UnmarshalJSON(t *testing.T) {
+func Test_Object_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name       string
-		json       string
-		wantOut    ObjectsToUpdate
+		data       []byte
+		wantObj    Object
 		wantErr    bool
 		wantErrMsg string
 	}{
 		{
-			name: "ObjectID, name/value",
-			json: `
-				[
-					{
-						"objectID": "23",
-						"property1": "mj"
-					}
-				]`,
-			wantOut: ObjectsToUpdate{
-				{"objectID": "23", "property1": "mj"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "ObjectID, name/operation (increment)",
-			json: `
-				[
-					{
-						"objectID": "24",
-						"property2": {
-							"operation": "Increment",
-							"value": 1
-						}
-					}
-				]`,
-			wantOut: ObjectsToUpdate{
-				{
-					"objectID": "24",
-					"property2": search.PartialUpdateOperation{
-						Operation: "Increment",
-						Value:     1,
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "No ObjectID",
-			json: `
-				[
-					{
-						"property1": "mj"
-					}
-				]`,
-			wantOut: ObjectsToUpdate{
-				{
-					"property1": "mj",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Wrong operation",
-			json: `
-				[
-					{
-						"objectID": "24",
-						"property2": {
-							"operation": "Unknown",
-							"value": "random"
-						}
-					}
-				]`,
+			name:       "empty object",
+			data:       []byte(`{}`),
 			wantErr:    true,
-			wantErrMsg: "Invalid operation type for object 1",
+			wantErrMsg: "objectID is required",
 		},
 		{
-			name: "Wrong operation structure",
-			json: `
-				[
-					{
-						"objectID": "24",
-						"property2": {
-							"type": "Unknown",
-							"value": "random"
-						}
-					}
-				]`,
+			name:       "missing objectID",
+			data:       []byte(`{"foo": "bar"}`),
 			wantErr:    true,
-			wantErrMsg: "Invalid operation for object 1",
+			wantErrMsg: "objectID is required",
+		},
+		{
+			name:    "valid object",
+			data:    []byte(`{"objectID": "foo"}`),
+			wantErr: false,
+			wantObj: Object{"objectID": "foo"},
+		},
+		{
+			name: "invalid operation type",
+			data: []byte(`{
+				"objectID": "foo",
+				"bar": {
+					"operation": "invalid"
+				}
+			}`),
+			wantErr:    true,
+			wantErrMsg: "invalid operation \"invalid\" (valid operations are Increment, Decrement, Add, AddUnique, IncrementSet and IncrementFrom)",
+		},
+		{
+			name: "missing operation",
+			data: []byte(`{
+				"objectID": "foo",
+				"bar": {
+					"foo": "bar"
+				}
+			}`),
+			wantErr:    true,
+			wantErrMsg: "missing operation",
+		},
+		{
+			name: "valid operation",
+			data: []byte(`{
+				"objectID": "foo",
+				"bar": {
+					"operation": "Increment"
+				}
+			}`),
+			wantErr: false,
+			wantObj: Object{"objectID": "foo", "bar": search.PartialUpdateOperation{Operation: "Increment"}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var objectsToUpdate ObjectsToUpdate
-			err := json.Unmarshal([]byte(tt.json), &objectsToUpdate)
-
-			if err != nil {
-				assert.Equal(t, tt.wantErr, true)
-				assert.EqualError(t, err, tt.wantErrMsg)
+			var o Object
+			err := o.UnmarshalJSON(tt.data)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantErrMsg, err.Error())
 				return
 			}
-
-			assert.EqualValues(t, objectsToUpdate, tt.wantOut)
-		})
-	}
-}
-
-func Test_isOperationTypeValid(t *testing.T) {
-	tests := []struct {
-		name          string
-		operationType string
-		wantOut       bool
-	}{
-		{
-			name:          "Correct operation type",
-			operationType: "Increment",
-			wantOut:       true,
-		},
-		{
-			name:          "Incorrect operation type (lowercase)",
-			operationType: "increment",
-			wantOut:       false,
-		},
-		{
-			name:          "Incorrect operation type",
-			operationType: "Unknown",
-			wantOut:       false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantOut, isOperationTypeValid(tt.operationType))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantObj, o)
 		})
 	}
 }

--- a/pkg/cmd/objects/update/update.go
+++ b/pkg/cmd/objects/update/update.go
@@ -1,0 +1,128 @@
+package updateObjects
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+type UpdateOptions struct {
+	Config config.IConfig
+	IO     *iostreams.IOStreams
+
+	SearchClient func() (*search.Client, error)
+
+	Index                          string
+	FilePath                       string
+	CreateIfNotExists              bool
+	AutoGenerateObjectIDIfNotExist bool
+
+	DoConfirm bool
+}
+
+// NewUpdateCmd creates and returns an update command for index objects
+func NewUpdateCmd(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Command {
+	var confirm bool
+
+	opts := &UpdateOptions{
+		IO:           f.IOStreams,
+		Config:       f.Config,
+		SearchClient: f.SearchClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:               "update <index> -F <file>",
+		Args:              validators.ExactArgs(1),
+		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
+		Short:             "Update objects from file to the specified index",
+		Long: heredoc.Doc(`
+			Update objects from JSON file to the specified index.
+			The JSON file must contains an array of valid objects
+		`),
+		Example: heredoc.Doc(`
+			# Update objects from the "objects.json" file to the "TEST_PRODUCTS" index
+			$ algolia objects update TEST_PRODUCTS -F objects.json
+
+			# Update objects (create if not exists) from the "objects.json" file to the "TEST_PRODUCTS" index
+			$ algolia objects update TEST_PRODUCTS -F objects.json --create-if-not-exists
+
+			# Update objects (create and auto generate objectID if not exists) from the "objects.json" file to the "TEST_PRODUCTS" index
+			$ algolia objects update TEST_PRODUCTS -F objects.json --create-if-not-exists --auto-generate-object-id-if-not-exist
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cs := opts.IO.ColorScheme()
+			opts.Index = args[0]
+
+			if !confirm {
+				if !opts.IO.CanPrompt() {
+					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
+				}
+				opts.DoConfirm = true
+			}
+
+			if opts.AutoGenerateObjectIDIfNotExist && !opts.CreateIfNotExists {
+				return fmt.Errorf("%s --auto-generate-object-id-if-not-exist flag can only be set if --create-if-not-exists flag is set", cs.FailureIcon())
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return runDeleteCmd(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "skip confirmation prompt")
+	cmd.Flags().StringVarP(&opts.FilePath, "file", "F", "", "Directory path of the JSON that contains updated objects")
+	_ = cmd.MarkFlagRequired("file")
+	cmd.Flags().BoolVarP(&opts.CreateIfNotExists, "create-if-not-exists", "c", false, "Updating a nonexistent object will create a new object")
+	cmd.Flags().BoolVarP(&opts.AutoGenerateObjectIDIfNotExist, "auto-generate-object-id-if-not-exist", "a", false, "The engine assigns an objectID to any object without objectID")
+
+	return cmd
+}
+
+func runDeleteCmd(opts *UpdateOptions) error {
+	cs := opts.IO.ColorScheme()
+
+	jsonFile, err := os.Open(opts.FilePath)
+	if err != nil {
+		return err
+	}
+	defer jsonFile.Close()
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return err
+	}
+	var objectsToUpdate ObjectsToUpdate
+	err = json.Unmarshal(byteValue, &objectsToUpdate)
+	if err != nil {
+		return err
+	}
+
+	client, err := opts.SearchClient()
+	if err != nil {
+		return err
+	}
+
+	index := client.InitIndex(opts.Index)
+
+	_, err = index.PartialUpdateObjects(objectsToUpdate,
+		opt.CreateIfNotExists(opts.CreateIfNotExists), opt.AutoGenerateObjectIDIfNotExist(opts.AutoGenerateObjectIDIfNotExist))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s %d objects successfully updated", cs.SuccessIcon(), len(objectsToUpdate))
+	return nil
+}

--- a/pkg/cmd/objects/update/update.go
+++ b/pkg/cmd/objects/update/update.go
@@ -117,8 +117,10 @@ func runDeleteCmd(opts *UpdateOptions) error {
 
 	index := client.InitIndex(opts.Index)
 
-	_, err = index.PartialUpdateObjects(objectsToUpdate,
-		opt.CreateIfNotExists(opts.CreateIfNotExists), opt.AutoGenerateObjectIDIfNotExist(opts.AutoGenerateObjectIDIfNotExist))
+	options := []interface{}{
+		opt.CreateIfNotExists(opts.CreateIfNotExists), opt.AutoGenerateObjectIDIfNotExist(opts.AutoGenerateObjectIDIfNotExist),
+	}
+	_, err = index.PartialUpdateObjects(objectsToUpdate, options)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/objects/update/update.go
+++ b/pkg/cmd/objects/update/update.go
@@ -1,10 +1,11 @@
-package updateObjects
+package update
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
+	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
@@ -14,6 +15,9 @@ import (
 	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/config"
 	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/prompt"
+	"github.com/algolia/cli/pkg/text"
+	"github.com/algolia/cli/pkg/utils"
 	"github.com/algolia/cli/pkg/validators"
 )
 
@@ -24,16 +28,17 @@ type UpdateOptions struct {
 	SearchClient func() (*search.Client, error)
 
 	Index             string
-	FilePath          string
 	CreateIfNotExists bool
+	Wait              bool
 
-	DoConfirm bool
+	File    string
+	Scanner *bufio.Scanner
+
+	ContinueOnError bool
 }
 
 // NewUpdateCmd creates and returns an update command for index objects
 func NewUpdateCmd(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Command {
-	var confirm bool
-
 	opts := &UpdateOptions{
 		IO:           f.IOStreams,
 		Config:       f.Config,
@@ -41,30 +46,36 @@ func NewUpdateCmd(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:               "update <index> -F <file>",
+		Use:               "update <index> -F <file> [--create-if-not-exists] [--wait] [--continue-on-errors]",
 		Args:              validators.ExactArgs(1),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
-		Short:             "Update objects from file to the specified index",
+		Short:             "Update objects from a file to the specified index",
 		Long: heredoc.Doc(`
-			Update objects from JSON file to the specified index.
-			The JSON file must contains an array of valid objects
+			Update objects from a file to the specified index.
+			
+			The file must contains one single JSON object per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
-			# Update objects from the "objects.json" file to the "TEST_PRODUCTS" index
-			$ algolia objects update TEST_PRODUCTS -F objects.json
+			# Update objects from the "objects.ndjson" file to the "TEST_PRODUCTS" index
+			$ algolia objects update TEST_PRODUCTS -F objects.ndjson
 
-			# Update objects (create if not exists) from the "objects.json" file to the "TEST_PRODUCTS" index
-			$ algolia objects update TEST_PRODUCTS -F objects.json --create-if-not-exists
+			# Update objects from the "objects.ndjson" file to the "TEST_PRODUCTS" index and create the objects if they don't exist
+			$ algolia objects update TEST_PRODUCTS -F objects.ndjson --create-if-not-exists
+
+			# Update objects from the "objects.ndjson" file to the "TEST_PRODUCTS" index and wait for the operation to complete
+			$ algolia objects update TEST_PRODUCTS -F objects.ndjson --wait
+
+			# Update objects from the "objects.ndjson" file to the "TEST_PRODUCTS" index and continue updating objects even if some objects are invalid
+			$ algolia objects update TEST_PRODUCTS -F objects.ndjson --continue-on-errors
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Index = args[0]
 
-			if !confirm {
-				if !opts.IO.CanPrompt() {
-					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
-				}
-				opts.DoConfirm = true
+			scanner, err := cmdutil.ScanFile(opts.File, opts.IO.In)
+			if err != nil {
+				return err
 			}
+			opts.Scanner = scanner
 
 			if runF != nil {
 				return runF(opts)
@@ -74,44 +85,110 @@ func NewUpdateCmd(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "skip confirmation prompt")
-	cmd.Flags().StringVarP(&opts.FilePath, "file", "F", "", "Directory path of the JSON that contains updated objects")
+	cmd.Flags().StringVarP(&opts.File, "file", "F", "", "Read objects to update from `file` (use \"-\" to read from standard input)")
 	_ = cmd.MarkFlagRequired("file")
-	cmd.Flags().BoolVarP(&opts.CreateIfNotExists, "create-if-not-exists", "c", false, "Updating a nonexistent object will create a new object")
+
+	cmd.Flags().BoolVarP(&opts.CreateIfNotExists, "create-if-not-exists", "c", false, "If provided, updating a nonexistent object will create a new object with the objectID and the attributes defined in the object")
+	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "Wait for the operation to complete before returning")
+
+	cmd.Flags().BoolVarP(&opts.ContinueOnError, "continue-on-error", "C", false, "Continue updating objects even if some objects are invalid.")
 
 	return cmd
 }
 
 func runDeleteCmd(opts *UpdateOptions) error {
-	cs := opts.IO.ColorScheme()
-
-	jsonFile, err := os.Open(opts.FilePath)
-	if err != nil {
-		return err
-	}
-	defer jsonFile.Close()
-	byteValue, err := ioutil.ReadAll(jsonFile)
-	if err != nil {
-		return err
-	}
-	var objectsToUpdate ObjectsToUpdate
-	err = json.Unmarshal(byteValue, &objectsToUpdate)
-	if err != nil {
-		return err
-	}
-
 	client, err := opts.SearchClient()
 	if err != nil {
 		return err
 	}
 
+	cs := opts.IO.ColorScheme()
 	index := client.InitIndex(opts.Index)
 
-	_, err = index.PartialUpdateObjects(objectsToUpdate, opt.CreateIfNotExists(opts.CreateIfNotExists))
-	if err != nil {
+	var (
+		objects      []interface{}
+		currentLine  = 0
+		totalObjects = 0
+	)
+
+	// Scan the file
+	opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Reading objects from %s", opts.File))
+	elapsed := time.Now()
+
+	var errors []string
+	for opts.Scanner.Scan() {
+		currentLine++
+		line := opts.Scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		totalObjects++
+		opts.IO.UpdateProgressIndicatorLabel(fmt.Sprintf("Read %s from %s", utils.Pluralize(totalObjects, "object"), opts.File))
+
+		var obj Object
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			err := fmt.Errorf("line %d: %s", currentLine, err)
+			errors = append(errors, err.Error())
+			continue
+		}
+
+		objects = append(objects, obj)
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	if err := opts.Scanner.Err(); err != nil {
 		return err
 	}
 
-	fmt.Printf("%s %d objects successfully updated", cs.SuccessIcon(), len(objectsToUpdate))
+	errorMsg := heredoc.Docf(`
+		%s Found %s (out of %d objects) while parsing the file:
+		%s
+	`, cs.FailureIcon(), utils.Pluralize(len(errors), "error"), totalObjects, text.Indent(strings.Join(errors, "\n"), "  "))
+
+	// No objects found
+	if len(objects) == 0 {
+		if len(errors) > 0 {
+			return fmt.Errorf(errorMsg)
+		}
+		return fmt.Errorf("%s No objects found in the file", cs.FailureIcon())
+	}
+
+	// Ask for confirmation if there are errors
+	if len(errors) > 0 {
+		if !opts.ContinueOnError {
+			fmt.Print(errorMsg)
+
+			var confirmed bool
+			err = prompt.Confirm("Do you want to continue?", &confirmed)
+			if err != nil {
+				return fmt.Errorf("failed to prompt: %w", err)
+			}
+			if !confirmed {
+				return nil
+			}
+		}
+	}
+
+	// Update the objects
+	opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Updating %s objects on %s", cs.Bold(fmt.Sprint(len(objects))), cs.Bold(opts.Index)))
+	res, err := index.PartialUpdateObjects(objects, opt.CreateIfNotExists(opts.CreateIfNotExists))
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	// Wait for the operation to complete if requested
+	if opts.Wait {
+		opts.IO.UpdateProgressIndicatorLabel("Waiting for operation to complete")
+		if err := res.Wait(); err != nil {
+			opts.IO.StopProgressIndicator()
+			return err
+		}
+	}
+
+	opts.IO.StopProgressIndicator()
+	fmt.Fprintf(opts.IO.Out, "%s Successfully updated %s objects on %s in %v\n", cs.SuccessIcon(), cs.Bold(fmt.Sprint(len(objects))), cs.Bold(opts.Index), time.Since(elapsed))
 	return nil
 }

--- a/pkg/cmd/objects/update/update_test.go
+++ b/pkg/cmd/objects/update/update_test.go
@@ -1,0 +1,97 @@
+package update
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+func Test_runExportCmd(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "objects.json")
+	err := os.WriteFile(tmpFile, []byte("{\"objectID\":\"foo\"}"), 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		cli     string
+		stdin   string
+		wantOut string
+		wantErr string
+	}{
+		{
+			name:    "from stdin",
+			cli:     "foo -F -",
+			stdin:   `{"objectID": "foo"}`,
+			wantOut: "✓ Successfully updated 1 objects on foo in",
+		},
+		{
+			name:    "from file",
+			cli:     fmt.Sprintf("foo -F '%s'", tmpFile),
+			wantOut: "✓ Successfully updated 1 objects on foo in",
+		},
+		{
+			name:    "from stdin with invalid JSON",
+			cli:     "foo -F -",
+			stdin:   `{"objectID": "foo"},`,
+			wantErr: "X Found 1 error (out of 1 objects) while parsing the file:\n  line 1: invalid character ',' after top-level value\n",
+		},
+		{
+			name: "from stdin with invalid JSON (multiple objects)",
+			cli:  "foo -F -",
+			stdin: `{"objectID": "foo"},
+			{"test": "bar"}`,
+			wantErr: "X Found 2 errors (out of 2 objects) while parsing the file:\n  line 1: invalid character ',' after top-level value\n  line 2: objectID is required\n",
+		},
+		{
+			name:    "from stdin with invalid JSON (1 object) with --continue-on-error",
+			cli:     "foo -F - --continue-on-error",
+			stdin:   `{"objectID": "foo"},`,
+			wantErr: "X Found 1 error (out of 1 objects) while parsing the file:\n  line 1: invalid character ',' after top-level value\n",
+		},
+		{
+			name: "from stdin with invalid JSON (2 objects) with --continue-on-error",
+			cli:  "foo -F - --continue-on-error",
+			stdin: `{"objectID": "foo"}
+			{"test": "bar"}`,
+			wantOut: "✓ Successfully updated 1 objects on foo in",
+		},
+		{
+			name:    "missing file flag",
+			cli:     "foo",
+			wantErr: "required flag(s) \"file\" not set",
+		},
+		{
+			name:    "non-existant file",
+			cli:     "foo -F /tmp/foo",
+			wantErr: "open /tmp/foo: no such file or directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httpmock.Registry{}
+			if tt.wantErr == "" {
+				r.Register(httpmock.REST("POST", "1/indexes/foo/batch"), httpmock.JSONResponse(search.BatchRes{}))
+			}
+			defer r.Verify(t)
+
+			f, out := test.NewFactory(true, &r, nil, tt.stdin)
+			cmd := NewUpdateCmd(f, nil)
+			out, err := test.Execute(cmd, tt.cli, out)
+			if err != nil {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			assert.Contains(t, out.String(), tt.wantOut)
+		})
+	}
+}


### PR DESCRIPTION
## Description:
The objects update command is available, allowing the users to partially update the objects in their indices.

### [API reference](https://www.algolia.com/doc/api-reference/api-methods/partial-update-objects/)

## Notes 
- Can't make [`autoGenerateObjectIDIfNotExist`](https://www.algolia.com/doc/api-reference/api-methods/partial-update-objects/#method-param-autogenerateobjectidifnotexist) work. Got this error: "could not generate intermediate batch: missing `objectID` field in object"