### PR TITLE
[DEX-332] Add events tail command

### DIFF
--- a/api/insights/client.go
+++ b/api/insights/client.go
@@ -1,0 +1,66 @@
+package insights
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
+	_insights "github.com/algolia/algoliasearch-client-go/v3/algolia/insights"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
+)
+
+// Client provides methods to interact with the Algolia Insights API.
+type Client struct {
+	appID     string
+	transport *transport.Transport
+}
+
+// NewClient instantiates a new client able to interact with the Algolia
+// Insights API.
+func NewClient(appID, apiKey string) *Client {
+	return NewClientWithConfig(
+		_insights.Configuration{
+			AppID:  appID,
+			APIKey: apiKey,
+		},
+	)
+}
+
+// NewClientWithConfig instantiates a new client able to interact with the
+// Algolia Insights API.
+func NewClientWithConfig(config _insights.Configuration) *Client {
+	var hosts []*transport.StatefulHost
+
+	if config.Hosts == nil {
+		hosts = defaultHosts(config.Region)
+	} else {
+		for _, h := range config.Hosts {
+			hosts = append(hosts, transport.NewStatefulHost(h, call.IsReadWrite))
+		}
+	}
+
+	return &Client{
+		appID: config.AppID,
+		transport: transport.New(
+			hosts,
+			config.Requester,
+			config.AppID,
+			config.APIKey,
+			config.ReadTimeout,
+			config.WriteTimeout,
+			config.Headers,
+			config.ExtraUserAgent,
+			compression.None,
+		),
+	}
+}
+
+// FetchEvents retrieves events from the Algolia Insights API.
+func (c *Client) FetchEvents(startDate, endDate time.Time, limit int) (EventsRes, error) {
+	var res EventsRes
+	path := fmt.Sprintf("/1/events?startDate=%s&endDate=%s&limit=%d", startDate.Format("2006-01-02T15:04:05.000Z"), endDate.Format("2006-01-02T15:04:05.000Z"), limit)
+	err := c.transport.Request(&res, http.MethodGet, path, nil, call.Read, nil)
+	return res, err
+}

--- a/api/insights/responses.go
+++ b/api/insights/responses.go
@@ -1,0 +1,5 @@
+package insights
+
+type EventsRes struct {
+	Events []EventWrapper `json:"events"`
+}

--- a/api/insights/types.go
+++ b/api/insights/types.go
@@ -1,0 +1,39 @@
+package insights
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type EventWrapper struct {
+	Event     Event    `json:"event"`
+	RequestID string   `json:"requestID"`
+	Status    int      `json:"status"`
+	Errors    []string `json:"errors"`
+	Headers   map[string][]string
+}
+
+type Timestamp struct {
+	time.Time
+}
+
+func (t *Timestamp) UnmarshalJSON(data []byte) error {
+	var timestamp int64
+	if err := json.Unmarshal(data, &timestamp); err != nil {
+		return err
+	}
+	*t = Timestamp{time.Unix(0, timestamp*int64(time.Millisecond))}
+	return nil
+}
+
+type Event struct {
+	EventType string    `json:"eventType"`
+	EventName string    `json:"eventName"`
+	Index     string    `json:"index"`
+	UserToken string    `json:"userToken"`
+	Timestamp Timestamp `json:"timestamp"`
+	ObjectIDs []string  `json:"objectIDs,omitempty"`
+	Positions []int     `json:"positions,omitempty"`
+	QueryID   string    `json:"queryID,omitempty"`
+	Filters   []string  `json:"filters,omitempty"`
+}

--- a/api/insights/utils.go
+++ b/api/insights/utils.go
@@ -1,0 +1,19 @@
+package insights
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
+)
+
+func defaultHosts(r region.Region) (hosts []*transport.StatefulHost) {
+	switch r {
+	case region.DE, region.US:
+		hosts = append(hosts, transport.NewStatefulHost(fmt.Sprintf("insights.%s.algolia.io", r), call.IsReadWrite))
+	default:
+		hosts = append(hosts, transport.NewStatefulHost("insights.algolia.io", call.IsReadWrite))
+	}
+	return
+}

--- a/pkg/cmd/events/events.go
+++ b/pkg/cmd/events/events.go
@@ -1,0 +1,20 @@
+package events
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmd/events/tail"
+	"github.com/algolia/cli/pkg/cmdutil"
+)
+
+// NewEventsCmd returns a new command for events.
+func NewEventsCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "events",
+		Short: "Manage your Algolia events",
+	}
+
+	cmd.AddCommand(tail.NewTailCmd(f, nil))
+
+	return cmd
+}

--- a/pkg/cmd/events/tail/tail.go
+++ b/pkg/cmd/events/tail/tail.go
@@ -1,0 +1,163 @@
+package tail
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/printers"
+	"github.com/algolia/cli/pkg/validators"
+
+	_insights "github.com/algolia/algoliasearch-client-go/v3/algolia/insights"
+	region "github.com/algolia/algoliasearch-client-go/v3/algolia/region"
+	"github.com/algolia/cli/api/insights"
+)
+
+const (
+	// DefaultRegion is the default region to use.
+	DefaultRegion = "us"
+
+	// Interval is the interval between each request to fetch events.
+	Interval = 3 * time.Second
+)
+
+// TailOptions contains all the options for the `events tail` command.
+type TailOptions struct {
+	Config config.IConfig
+	IO     *iostreams.IOStreams
+
+	SearchClient func() (*search.Client, error)
+
+	Region string
+
+	PrintFlags *cmdutil.PrintFlags
+}
+
+// NewTailCmd returns a new command for tailing events.
+func NewTailCmd(f *cmdutil.Factory, runF func(*TailOptions) error) *cobra.Command {
+	opts := &TailOptions{
+		IO:           f.IOStreams,
+		Config:       f.Config,
+		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
+	}
+	cmd := &cobra.Command{
+		Use:   "tail",
+		Args:  validators.NoArgs(),
+		Short: "Tail events",
+		Long: heredoc.Doc(`
+			Tail events from your Algolia application.
+
+			By default, this command will tail events for the United States region.
+			If your Analytics data is stored in a different region than the United States (e.g. Germany/Europe), you can specify the region using the --region (-r) flag.
+		`),
+		Example: heredoc.Doc(`
+			# Tail events
+			$ algolia events tail
+
+			# Tail events for a specific region matching the Analytics region of your application
+			$ algolia events tail -r de
+
+			# Tail events and output them as JSON
+			$ algolia events tail --output json
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return runTailCmd(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Region, "region", "r", DefaultRegion, "Region where your analytics data is stored and processed.")
+	_ = cmd.RegisterFlagCompletionFunc("region", cmdutil.StringCompletionFunc(map[string]string{
+		"us": "United States",
+		"de": "Germany (Europe)",
+	}))
+
+	opts.PrintFlags.AddFlags(cmd)
+
+	return cmd
+}
+
+func runTailCmd(opts *TailOptions) error {
+	appID, err := opts.Config.Profile().GetApplicationID()
+	if err != nil {
+		return err
+	}
+	apiKey, err := opts.Config.Profile().GetAdminAPIKey()
+	if err != nil {
+		return err
+	}
+
+	// We don't use the base insights client because it doesn't support fetching events.
+	config := _insights.Configuration{
+		AppID:  appID,
+		APIKey: apiKey,
+		Region: region.Region(opts.Region),
+	}
+	insightsClient := insights.NewClientWithConfig(config)
+
+	var p printers.Printer
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err = opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+	} else if opts.IO.IsStdoutTTY() {
+		fmt.Fprint(opts.IO.Out, "\nWaiting for events... Press Ctrl+C to stop.\n")
+	}
+
+	c := time.Tick(Interval)
+	for t := range c {
+		utc := t.UTC()
+		events, err := insightsClient.FetchEvents(utc.Add(-1*time.Second), utc, 1000)
+		if err != nil {
+			if strings.Contains(err.Error(), "The log processing region does not match") {
+				cs := opts.IO.ColorScheme()
+				errDetails := heredoc.Docf(`
+					%s The Analytics storage region of your application does not match the region you specified (%s).
+					Please specify the correct region using the --region (-r) flag.
+					You can view the Analytics storage region of your application in the Algolia dashboard: https://www.algolia.com/infra/analytics
+				`, cs.FailureIcon(), opts.Region)
+				return errors.New(errDetails)
+			}
+		}
+
+		for _, event := range events.Events {
+			if p != nil {
+				if err := p.Print(opts.IO, event); err != nil {
+					return err
+				}
+			} else {
+				printEvent(opts.IO, event)
+			}
+		}
+	}
+
+	return nil
+}
+
+func printEvent(io *iostreams.IOStreams, event insights.EventWrapper) {
+	cs := io.ColorScheme()
+
+	timeLayout := "2006-01-02 15:04:05"
+	formatedTime := event.Event.Timestamp.Format(timeLayout)
+	formatedTime = cs.Gray(formatedTime)
+
+	colorizedStatus := cs.Green(fmt.Sprint(event.Status))
+	if event.Status > 200 {
+		colorizedStatus = cs.Red(fmt.Sprint(event.Status))
+	}
+
+	fmt.Fprintf(io.Out, "%s [%s] %s %s [%s] %s\n", cs.Bold(formatedTime), colorizedStatus, event.Event.EventType, cs.Bold(event.Event.Index), event.Event.EventName, event.Event.UserToken)
+}

--- a/pkg/cmd/events/tail/tail.go
+++ b/pkg/cmd/events/tail/tail.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// DefaultRegion is the default region to use.
-	DefaultRegion = "us"
+	DefaultRegion = region.US
 
 	// Interval is the interval between each request to fetch events.
 	Interval = 3 * time.Second
@@ -78,10 +78,10 @@ func NewTailCmd(f *cmdutil.Factory, runF func(*TailOptions) error) *cobra.Comman
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Region, "region", "r", DefaultRegion, "Region where your analytics data is stored and processed.")
+	cmd.Flags().StringVarP(&opts.Region, "region", "r", string(DefaultRegion), "Region where your analytics data is stored and processed.")
 	_ = cmd.RegisterFlagCompletionFunc("region", cmdutil.StringCompletionFunc(map[string]string{
-		"us": "United States",
-		"de": "Germany (Europe)",
+		string(region.US): "United States",
+		string(region.DE): "Germany (Europe)",
 	}))
 
 	opts.PrintFlags.AddFlags(cmd)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/algolia/cli/pkg/cmd/apikeys"
 	"github.com/algolia/cli/pkg/cmd/art"
 	"github.com/algolia/cli/pkg/cmd/dictionary"
+	"github.com/algolia/cli/pkg/cmd/events"
 	"github.com/algolia/cli/pkg/cmd/factory"
 	"github.com/algolia/cli/pkg/cmd/indices"
 	"github.com/algolia/cli/pkg/cmd/objects"
@@ -98,6 +99,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(rules.NewRulesCmd(f))
 	cmd.AddCommand(synonyms.NewSynonymsCmd(f))
 	cmd.AddCommand(dictionary.NewDictionaryCmd(f))
+	cmd.AddCommand(events.NewEventsCmd(f))
 
 	// ??? related commands
 	cmd.AddCommand(art.NewArtCmd(f))


### PR DESCRIPTION
This PR add a new `events tail` command.

<img width="654" alt="Screenshot 2022-12-20 at 17 08 50" src="https://user-images.githubusercontent.com/5702266/208615957-1391ba39-3de1-4c00-b4bc-dcf99a0f4970.png">
