### PR TITLE
[DEX-386] Add windows support and release to chocolatey

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,6 +20,15 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.19
+      - name: Install chocolatey
+        run: |
+          mkdir -p /opt/chocolatey
+          wget -q -O - "https://github.com/chocolatey/choco/releases/download/${CHOCOLATEY_VERSION}/chocolatey.v${CHOCOLATEY_VERSION}.tar.gz" | tar -xz -C "/opt/chocolatey"
+          echo '#!/bin/bash' >> /usr/local/bin/choco
+          echo 'mono /opt/chocolatey/choco.exe $@' >> /usr/local/bin/choco
+          chmod +x /usr/local/bin/choco
+        env:
+          CHOCOLATEY_VERSION: 1.2.0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.8.0
         with:
@@ -27,6 +36,7 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
       - name: Docs checkout
         uses: actions/checkout@v3
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -114,9 +114,9 @@ chocolateys:
       - windows
     project_url: https://algolia.com/doc/tools/cli
     url_template: "https://github.com/algolia/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    icon_url: 'https://raw.githubusercontent.com/algolia/cli/master/screenshots/logo.png'
+    icon_url: 'https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiYWxnb2xpYS1icmFuZFwvZmlsZVwvRGVRczRpYzJpcWRwcHNQaTQ0aVoucG5nIn0:algolia-brand:iMztVbeCSM-SuJ011FE1EigUhc-yZZ5RPPpmq6DP8T0?width=300'
     copyright: 2023 Algolia
-    license_url: https://github.com/algolia/cli/blob/master/LICENSE
+    license_url: https://github.com/algolia/cli/blob/main/LICENSE
     require_license_acceptance: false
     project_source_url: https://github.com/algolia/cli
     docs_url: https://algolia.com/doc/tools/cli

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,11 @@ builds:
     env:
       - CGO_ENABLED=0
 
+  - <<: *build_defaults
+    id: windows
+    goos: [windows]
+    goarch: [386, amd64, arm64]
+
 archives:
   - id: nix
     builds: [macos, linux]
@@ -99,3 +104,30 @@ dockers:
       - algolia
       - algolia-linux-arm
     <<: *docker_defaults
+
+chocolateys:
+  -
+    name: algolia
+    title: Algolia CLI
+    authors: Algolia
+    ids:
+      - windows
+    project_url: https://algolia.com/doc/tools/cli
+    url_template: "https://github.com/algolia/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    icon_url: 'https://raw.githubusercontent.com/algolia/cli/master/screenshots/logo.png'
+    copyright: 2023 Algolia
+    license_url: https://github.com/algolia/cli/blob/master/LICENSE
+    require_license_acceptance: false
+    project_source_url: https://github.com/algolia/cli
+    docs_url: https://algolia.com/doc/tools/cli
+    bug_tracker_url: https://github.com/algolia/cli/issues
+    tags: "algolia search cli automation interface command-line tool devtool"
+    summary: Algolia's official CLI devtool
+    description: |
+      {{ .ProjectName }} chocolatey installer package.
+      A command line interface to enable Algolia developers to interact with and configure their Algolia applications straight from a command line or terminal window. Automate common workloads, create snapshots, revert to backups, or quickly modify applications as needed! This is a lightweight tool, providing a text-only interface, that is easy to install and use!
+    release_notes: "https://github.com/algolia/cli/releases/tag/v{{ .Version }}"
+    api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
+    source_repo: "https://push.chocolatey.org/"
+    skip_publish: false
+    goamd64: v1

--- a/pkg/iostreams/console.go
+++ b/pkg/iostreams/console.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package iostreams
 
 import (
@@ -9,6 +7,12 @@ import (
 
 func (s *IOStreams) EnableVirtualTerminalProcessing() error {
 	return nil
+}
+
+func hasAlternateScreenBuffer(hasTrueColor bool) bool {
+	// on Windows we just assume that alternate screen buffer is supported if we
+	// enabled virtual terminal processing, which in turn enables truecolor
+	return hasTrueColor
 }
 
 func enableVirtualTerminalProcessing(f *os.File) error {

--- a/pkg/iostreams/console.go
+++ b/pkg/iostreams/console.go
@@ -9,7 +9,7 @@ func (s *IOStreams) EnableVirtualTerminalProcessing() error {
 	return nil
 }
 
-func hasAlternateScreenBuffer(hasTrueColor bool) bool {
+func HasAlternateScreenBuffer(hasTrueColor bool) bool {
 	// on Windows we just assume that alternate screen buffer is supported if we
 	// enabled virtual terminal processing, which in turn enables truecolor
 	return hasTrueColor

--- a/pkg/iostreams/tty_size_windows.go
+++ b/pkg/iostreams/tty_size_windows.go
@@ -1,0 +1,15 @@
+package iostreams
+
+import (
+	"errors"
+	"golang.org/x/term"
+)
+
+func ttySize() (int, int, error) {
+	// in case we are not in a terminal
+	if !term.IsTerminal(0) {
+		return -1, -1, errors.New("not a terminal")
+	}
+
+	return term.GetSize(0)
+}


### PR DESCRIPTION
This PR enables our goreleaser to create a windows build (`.exe`) and pushes it as a package to Chocolatey.

Chocolatey doesn't require a signed executable making it possible to build a `nupkg` and installing it without needing a signed exe.

Chocolatey has a [heavy moderation process](https://docs.chocolatey.org/en-us/community-repository/moderation/), therefore it may take quite some time before the package gets approved (2-3 days) per my experience.

The following PR should pass the automated review if all the links added to the chocolatey releaser are not broken links (should therefore be double checked) 