### PR TITLE
fix(cli): check error when writing on the output

### DIFF
--- a/pkg/cmd/dictionary/entries/browse/browse.go
+++ b/pkg/cmd/dictionary/entries/browse/browse.go
@@ -144,10 +144,14 @@ func runBrowseCmd(opts *BrowseOptions) error {
 			for _, entry := range entries {
 				if opts.IncludeDefaultStopwords {
 					// print all entries (default stopwords included)
-					p.Print(opts.IO, entry)
+					if err = p.Print(opts.IO, entry); err != nil {
+						return err
+					}
 				} else if entry.Type == shared.CustomEntryType {
 					// print only custom entries
-					p.Print(opts.IO, entry)
+					if err = p.Print(opts.IO, entry); err != nil {
+						return err
+					}
 				}
 			}
 
@@ -156,7 +160,9 @@ func runBrowseCmd(opts *BrowseOptions) error {
 
 		// in case no entry is found in all the dictionaries
 		if hasNoEntries {
-			fmt.Fprintf(opts.IO.Out, "%s No entries found.\n\n", cs.WarningIcon())
+			if _, err = fmt.Fprintf(opts.IO.Out, "%s No entries found.\n\n", cs.WarningIcon()); err != nil {
+				return err
+			}
 			// go to the next dictionary
 			break
 		}

--- a/pkg/cmd/dictionary/entries/clear/clear.go
+++ b/pkg/cmd/dictionary/entries/clear/clear.go
@@ -126,7 +126,9 @@ func runClearCmd(opts *ClearOptions) error {
 	}
 
 	if totalEntries == 0 {
-		fmt.Fprintf(opts.IO.Out, "%s No entries to clear in %s dictionary.\n", cs.WarningIcon(), utils.SliceToReadableString(dictionariesNames))
+		if _, err = fmt.Fprintf(opts.IO.Out, "%s No entries to clear in %s dictionary.\n", cs.WarningIcon(), utils.SliceToReadableString(dictionariesNames)); err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/pkg/cmd/dictionary/entries/import/import.go
+++ b/pkg/cmd/dictionary/entries/import/import.go
@@ -141,7 +141,6 @@ func runImportCmd(opts *ImportOptions) error {
 	opts.IO.StopProgressIndicator()
 
 	if err := opts.Scanner.Err(); err != nil {
-
 		return err
 	}
 
@@ -193,8 +192,8 @@ func runImportCmd(opts *ImportOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
-	fmt.Fprintf(opts.IO.Out, "%s Successfully imported %s entries on %s in %v\n", cs.SuccessIcon(), cs.Bold(fmt.Sprint(len(entries))), cs.Bold(opts.DictionaryName), time.Since(elapsed))
-	return nil
+	_, err = fmt.Fprintf(opts.IO.Out, "%s Successfully imported %s entries on %s in %v\n", cs.SuccessIcon(), cs.Bold(fmt.Sprint(len(entries))), cs.Bold(opts.DictionaryName), time.Since(elapsed))
+	return err
 }
 
 func ValidateDictionaryEntry(entry shared.DictionaryEntry, currentLine int) error {

--- a/pkg/cmd/events/tail/tail.go
+++ b/pkg/cmd/events/tail/tail.go
@@ -139,7 +139,9 @@ func runTailCmd(opts *TailOptions) error {
 					return err
 				}
 			} else {
-				printEvent(opts.IO, event)
+				if err := printEvent(opts.IO, event); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -147,7 +149,7 @@ func runTailCmd(opts *TailOptions) error {
 	return nil
 }
 
-func printEvent(io *iostreams.IOStreams, event insights.EventWrapper) {
+func printEvent(io *iostreams.IOStreams, event insights.EventWrapper) error {
 	cs := io.ColorScheme()
 
 	timeLayout := "2006-01-02 15:04:05"
@@ -159,5 +161,6 @@ func printEvent(io *iostreams.IOStreams, event insights.EventWrapper) {
 		colorizedStatus = cs.Red(fmt.Sprint(event.Status))
 	}
 
-	fmt.Fprintf(io.Out, "%s [%s] %s %s [%s] %s\n", cs.Bold(formatedTime), colorizedStatus, event.Event.EventType, cs.Bold(event.Event.Index), event.Event.EventName, event.Event.UserToken)
+	_, err := fmt.Fprintf(io.Out, "%s [%s] %s %s [%s] %s\n", cs.Bold(formatedTime), colorizedStatus, event.Event.EventType, cs.Bold(event.Event.Index), event.Event.EventName, event.Event.UserToken)
+	return err
 }

--- a/pkg/cmd/objects/browse/browse.go
+++ b/pkg/cmd/objects/browse/browse.go
@@ -110,6 +110,9 @@ func runBrowseCmd(opts *BrowseOptions) error {
 			}
 			return err
 		}
-		p.Print(opts.IO, iObject)
+		if err = p.Print(opts.IO, iObject); err != nil {
+			return err
+		}
+
 	}
 }

--- a/pkg/cmd/objects/delete/delete.go
+++ b/pkg/cmd/objects/delete/delete.go
@@ -138,7 +138,9 @@ func runDeleteCmd(opts *DeleteOptions) error {
 	}
 
 	if nbObjectsToDelete == 0 {
-		fmt.Fprintf(opts.IO.Out, "%s No objects to delete. %s\n", cs.WarningIcon(), extra)
+		if _, err = fmt.Fprintf(opts.IO.Out, "%s No objects to delete. %s\n", cs.WarningIcon(), extra); err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/pkg/cmd/objects/operations/operations.go
+++ b/pkg/cmd/objects/operations/operations.go
@@ -163,7 +163,6 @@ func runOperationsCmd(opts *OperationsOptions) error {
 	// Process operations
 	opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Processing %s operations", cs.Bold(fmt.Sprint(len(operations)))))
 	res, err := client.MultipleBatch(operations)
-
 	if err != nil {
 		opts.IO.StopProgressIndicator()
 		return err
@@ -179,14 +178,16 @@ func runOperationsCmd(opts *OperationsOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
-	fmt.Fprintf(opts.IO.Out, "%s Successfully processed %s operations in %v\n", cs.SuccessIcon(), cs.Bold(fmt.Sprint(len(operations))), time.Since(elapsed))
-	return nil
+	_, err = fmt.Fprintf(opts.IO.Out, "%s Successfully processed %s operations in %v\n", cs.SuccessIcon(), cs.Bold(fmt.Sprint(len(operations))), time.Since(elapsed))
+	return err
 }
 
 // ValidateBatchOperation checks that the batch operation is valid
 func ValidateBatchOperation(p search.BatchOperationIndexed) error {
-	allowedActions := []string{string(search.AddObject), string(search.UpdateObject), string(search.PartialUpdateObject),
-		string(search.PartialUpdateObjectNoCreate), string(search.DeleteObject)}
+	allowedActions := []string{
+		string(search.AddObject), string(search.UpdateObject), string(search.PartialUpdateObject),
+		string(search.PartialUpdateObjectNoCreate), string(search.DeleteObject),
+	}
 	extra := fmt.Sprintf("valid actions are %s", utils.SliceToReadableString(allowedActions))
 
 	if p.Action == "" {

--- a/pkg/cmd/objects/update/update.go
+++ b/pkg/cmd/objects/update/update.go
@@ -189,6 +189,6 @@ func runUpdateCmd(opts *UpdateOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
-	fmt.Fprintf(opts.IO.Out, "%s Successfully updated %s objects on %s in %v\n", cs.SuccessIcon(), cs.Bold(fmt.Sprint(len(objects))), cs.Bold(opts.Index), time.Since(elapsed))
-	return nil
+	_, err = fmt.Fprintf(opts.IO.Out, "%s Successfully updated %s objects on %s in %v\n", cs.SuccessIcon(), cs.Bold(fmt.Sprint(len(objects))), cs.Bold(opts.Index), time.Since(elapsed))
+	return err
 }

--- a/pkg/cmd/profile/add/add.go
+++ b/pkg/cmd/profile/add/add.go
@@ -164,7 +164,9 @@ func runAddCmd(opts *AddOptions) error {
 			}
 		}
 
-		fmt.Fprintf(opts.IO.Out, "%s Profile '%s' (%s) added successfully%s\n", cs.SuccessIcon(), opts.Profile.Name, opts.Profile.ApplicationID, extra)
+		if _, err = fmt.Fprintf(opts.IO.Out, "%s Profile '%s' (%s) added successfully%s\n", cs.SuccessIcon(), opts.Profile.Name, opts.Profile.ApplicationID, extra); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cmd/profile/remove/remove.go
+++ b/pkg/cmd/profile/remove/remove.go
@@ -103,7 +103,9 @@ func runRemoveCmd(opts *RemoveOptions) error {
 		if len(opts.config.ConfiguredProfiles()) == 0 {
 			extra = ". Add a profile with 'algolia profile add'."
 		}
-		fmt.Fprintf(opts.IO.Out, "%s '%s' removed successfully%s\n", cs.SuccessIcon(), opts.Profile, extra)
+		if _, err = fmt.Fprintf(opts.IO.Out, "%s '%s' removed successfully%s\n", cs.SuccessIcon(), opts.Profile, extra); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cmd/profile/setdefault/setdefault.go
+++ b/pkg/cmd/profile/setdefault/setdefault.go
@@ -76,9 +76,13 @@ func runSetDefaultCmd(opts *SetDefaultOptions) error {
 
 	if opts.IO.IsStdoutTTY() {
 		if defaultName != "" {
-			fmt.Fprintf(opts.IO.Out, "%s Default profile successfuly changed from '%s' to '%s'.\n", cs.SuccessIcon(), defaultName, opts.Profile)
+			if _, err = fmt.Fprintf(opts.IO.Out, "%s Default profile successfuly changed from '%s' to '%s'.\n", cs.SuccessIcon(), defaultName, opts.Profile); err != nil {
+				return err
+			}
 		} else {
-			fmt.Fprintf(opts.IO.Out, "%s Default profile successfuly set to '%s'.\n", cs.SuccessIcon(), opts.Profile)
+			if _, err = fmt.Fprintf(opts.IO.Out, "%s Default profile successfuly set to '%s'.\n", cs.SuccessIcon(), opts.Profile); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/cmd/rules/browse/browse.go
+++ b/pkg/cmd/rules/browse/browse.go
@@ -83,6 +83,8 @@ func runListCmd(opts *ExportOptions) error {
 			}
 			return err
 		}
-		p.Print(opts.IO, iObject)
+		if err = p.Print(opts.IO, iObject); err != nil {
+			return err
+		}
 	}
 }

--- a/pkg/cmd/synonyms/browse/browse.go
+++ b/pkg/cmd/synonyms/browse/browse.go
@@ -82,6 +82,8 @@ func runBrowseCmd(opts *BrowseOptions) error {
 			}
 			return err
 		}
-		p.Print(opts.IO, iObject)
+		if err = p.Print(opts.IO, iObject); err != nil {
+			return err
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Check error when writing on the output: I dumped a large index on a disk full and the cli didn't return an error.

I only added error handling for the calls without check on `IO.IsStdoutTTY` or using `IO.ErrOut`.