### PR TITLE
feat(cli): also delete replica indices

### DIFF
--- a/pkg/cmd/indices/delete/delete.go
+++ b/pkg/cmd/indices/delete/delete.go
@@ -77,7 +77,7 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "skip confirmation prompt")
-	cmd.Flags().BoolVarP(&opts.IncludeReplicas, "includeReplicas", "", false, "delete replica indices too")
+	cmd.Flags().BoolVarP(&opts.IncludeReplicas, "includeReplicas", "r", false, "delete replica indices too")
 
 	return cmd
 }

--- a/pkg/cmd/indices/delete/delete.go
+++ b/pkg/cmd/indices/delete/delete.go
@@ -144,7 +144,7 @@ func runDeleteCmd(opts *DeleteOptions) error {
 
 		// Otherwise, the replica indices might not be 'fully detached' yet.
 		if mustWait {
-			res.Wait()
+			_ = res.Wait()
 		}
 
 		if err != nil {

--- a/pkg/cmd/indices/delete/delete_test.go
+++ b/pkg/cmd/indices/delete/delete_test.go
@@ -157,10 +157,18 @@ func Test_runDeleteCmd(t *testing.T) {
 				// First settings call with `Exists()`
 				r.Register(httpmock.REST("GET", fmt.Sprintf("1/indexes/%s/settings", index)), httpmock.JSONResponse(search.Settings{}))
 				if tt.hasReplicas {
-					// Settings call to detect if there are replicas
+					// Settings calls for the primary index and its replicas
 					r.Register(httpmock.REST("GET", fmt.Sprintf("1/indexes/%s/settings", index)), httpmock.JSONResponse(search.Settings{
 						Replicas: opt.Replicas("bar"),
 					}))
+					r.Register(httpmock.REST("GET", fmt.Sprintf("1/indexes/%s/settings", index)), httpmock.JSONResponse(search.Settings{
+						Replicas: opt.Replicas("bar"),
+					}))
+					r.Register(httpmock.REST("GET", "1/indexes/bar/settings"), httpmock.JSONResponse(search.Settings{
+						Primary: opt.Primary("foo"),
+					}))
+					// Additional DELETE calls for the replicas
+					r.Register(httpmock.REST("DELETE", "1/indexes/bar"), httpmock.JSONResponse(search.Settings{}))
 				}
 				if tt.isReplica {
 					// We want the first `Delete()` call to fail

--- a/pkg/cmd/indices/delete/delete_test.go
+++ b/pkg/cmd/indices/delete/delete_test.go
@@ -122,8 +122,8 @@ func Test_runDeleteCmd(t *testing.T) {
 			name:    "no TTY, multiple indices",
 			cli:     "foo bar --confirm",
 			indices: []string{"foo", "bar"},
-			isTTY:   true,
-			wantOut: "✓ Deleted indices foo, bar\n",
+			isTTY:   false,
+			wantOut: "",
 		},
 		{
 			name:    "TTY, multiple indices",


### PR DESCRIPTION
This PR adds a new boolean option to the `algolia indices delete` command: `--includeReplicas`. 
If it's true, the command will look for any replicas of an index and deletes them with the primary index. No more dangling indices because of replicas. 

[DEX-784]



[DEX-784]: https://algolia.atlassian.net/browse/DEX-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ