### PR TITLE
fix: documentation rendering issues

### DIFF
--- a/internal/docs/yaml.go
+++ b/internal/docs/yaml.go
@@ -100,7 +100,7 @@ func GenYamlTree(cmd *cobra.Command, dir string) error {
 
 	for i, c := range commands {
 		command_path := strings.ReplaceAll(c.Name, " ", "_")
-		filename := filepath.Join(dir, fmt.Sprintf("0%d-%s.yml", i+1, command_path))
+		filename := filepath.Join(dir, fmt.Sprintf("%02d-%s.yml", i+1, command_path))
 		f, err := os.Create(filename)
 		if err != nil {
 			return err

--- a/internal/docs/yaml.go
+++ b/internal/docs/yaml.go
@@ -91,8 +91,14 @@ func GenYamlTree(cmd *cobra.Command, dir string) error {
 		}
 		command := newCommand(c)
 		if c.HasAvailableSubCommands() {
-			for _, sub := range c.Commands() {
-				command.SubCommands = append(command.SubCommands, newCommand(sub))
+			for _, s := range c.Commands() {
+				sub := newCommand(s)
+				if s.HasAvailableSubCommands() {
+					for _, sus := range s.Commands() {
+						sub.SubCommands = append(sub.SubCommands, newCommand(sus))
+					}
+				}
+				command.SubCommands = append(command.SubCommands, sub)
 			}
 		}
 		commands = append(commands, command)

--- a/internal/docs/yaml.go
+++ b/internal/docs/yaml.go
@@ -104,9 +104,9 @@ func GenYamlTree(cmd *cobra.Command, dir string) error {
 		commands = append(commands, command)
 	}
 
-	for i, c := range commands {
+	for _, c := range commands {
 		command_path := strings.ReplaceAll(c.Name, " ", "_")
-		filename := filepath.Join(dir, fmt.Sprintf("%02d-%s.yml", i+1, command_path))
+		filename := filepath.Join(dir, fmt.Sprintf("%s.yml", command_path))
 		f, err := os.Create(filename)
 		if err != nil {
 			return err

--- a/pkg/cmd/dictionary/dictionary.go
+++ b/pkg/cmd/dictionary/dictionary.go
@@ -9,7 +9,7 @@ import (
 	"github.com/algolia/cli/pkg/cmdutil"
 )
 
-// NewDictionaryCmd returns a new command for dictionnaries.
+// NewDictionaryCmd returns a new command for dictionaries.
 func NewDictionaryCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dictionary",

--- a/pkg/cmd/dictionary/entries/browse/browse.go
+++ b/pkg/cmd/dictionary/entries/browse/browse.go
@@ -21,7 +21,7 @@ type BrowseOptions struct {
 
 	SearchClient func() (*search.Client, error)
 
-	Dictionnaries           []search.DictionaryName
+	Dictionaries            []search.DictionaryName
 	All                     bool
 	IncludeDefaultStopwords bool
 
@@ -38,7 +38,7 @@ type DictionaryEntry struct {
 	Language      string
 }
 
-// NewBrowseCmd creates and returns a browse command for dictionnaries' entries.
+// NewBrowseCmd creates and returns a browse command for dictionaries' entries.
 func NewBrowseCmd(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Command {
 	cs := f.IOStreams.ColorScheme()
 
@@ -57,19 +57,19 @@ func NewBrowseCmd(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 		},
 		Short: "Browse dictionary entries",
 		Long: heredoc.Docf(`
-			This command retrieves all entries from the specified %s dictionnaries.
+			This command retrieves all entries from the specified %s dictionaries.
 		`, cs.Bold("custom")),
 		Example: heredoc.Doc(`
 			# Retrieve all entries from the "stopwords" dictionary (doesn't include default stopwords)
 			$ algolia dictionary entries browse stopwords
 
-			# Retrieve all entries from the "stopwords" and "plurals" dictionnaries
+			# Retrieve all entries from the "stopwords" and "plurals" dictionaries
 			$ algolia dictionary entries browse stopwords plurals
 
-			# Retrieve all entries from all dictionnaries
+			# Retrieve all entries from all dictionaries
 			$ algolia dictionary entries browse --all
 
-			# Retrieve all entries from the "stopwords" dictionnaries (including default stopwords)
+			# Retrieve all entries from the "stopwords" dictionaries (including default stopwords)
 			$ algolia dictionary entries browse stopwords --include-defaults
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -78,11 +78,11 @@ func NewBrowseCmd(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 			}
 
 			if opts.All {
-				opts.Dictionnaries = []search.DictionaryName{search.Stopwords, search.Plurals, search.Compounds}
+				opts.Dictionaries = []search.DictionaryName{search.Stopwords, search.Plurals, search.Compounds}
 			} else {
-				opts.Dictionnaries = make([]search.DictionaryName, len(args))
-				for i, dictionnary := range args {
-					opts.Dictionnaries[i] = search.DictionaryName(dictionnary)
+				opts.Dictionaries = make([]search.DictionaryName, len(args))
+				for i, dictionary := range args {
+					opts.Dictionaries[i] = search.DictionaryName(dictionary)
 				}
 			}
 
@@ -90,7 +90,7 @@ func NewBrowseCmd(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "browse all dictionnaries")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "browse all dictionaries")
 	cmd.Flags().BoolVarP(&opts.IncludeDefaultStopwords, "include-defaults", "d", false, "include default stopwords")
 
 	opts.PrintFlags.AddFlags(cmd)
@@ -113,13 +113,13 @@ func runBrowseCmd(opts *BrowseOptions) error {
 
 	hasNoEntries := true
 
-	for _, dictionnary := range opts.Dictionnaries {
+	for _, dictionary := range opts.Dictionaries {
 		pageCount := 0
 		maxPages := 1
 
 		// implement infinite pagination
 		for pageCount < maxPages {
-			res, err := client.SearchDictionaryEntries(dictionnary, "", opt.HitsPerPage(1000), opt.Page(pageCount))
+			res, err := client.SearchDictionaryEntries(dictionary, "", opt.HitsPerPage(1000), opt.Page(pageCount))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/dictionary/entries/browse/browse_test.go
+++ b/pkg/cmd/dictionary/entries/browse/browse_test.go
@@ -54,7 +54,7 @@ func Test_runBrowseCmd(t *testing.T) {
 			wantOut: "{\"Type\":\"custom\",\"ObjectID\":\"\",\"Language\":\"\"}\n{\"Type\":\"custom\",\"ObjectID\":\"\",\"Language\":\"\"}\n{\"Type\":\"custom\",\"ObjectID\":\"\",\"Language\":\"\"}\n",
 		},
 		{
-			name: "one dictionnary with default stopwords",
+			name: "one dictionary with default stopwords",
 			cli:  "--all --include-defaults",
 			dictionaries: []search.DictionaryName{
 				search.Stopwords,

--- a/pkg/cmd/dictionary/entries/clear/clear.go
+++ b/pkg/cmd/dictionary/entries/clear/clear.go
@@ -24,8 +24,8 @@ type ClearOptions struct {
 
 	SearchClient func() (*search.Client, error)
 
-	Dictionnaries []search.DictionaryName
-	All           bool
+	Dictionaries []search.DictionaryName
+	All          bool
 
 	DoConfirm bool
 }
@@ -34,7 +34,7 @@ type DictionaryEntry struct {
 	Type shared.EntryType
 }
 
-// NewClearCmd creates and returns a clear command for dictionnaries' entries.
+// NewClearCmd creates and returns a clear command for dictionaries' entries.
 func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Command {
 	var confirm bool
 	cs := f.IOStreams.ColorScheme()
@@ -45,7 +45,7 @@ func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Comm
 		SearchClient: f.SearchClient,
 	}
 	cmd := &cobra.Command{
-		Use:       "clear {<dictionnary>... | --all} [--confirm]",
+		Use:       "clear {<dictionary>... | --all} [--confirm]",
 		Args:      cobra.OnlyValidArgs,
 		ValidArgs: shared.DictionaryNames(),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -53,29 +53,29 @@ func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Comm
 		},
 		Short: "Clear dictionary entries",
 		Long: heredoc.Docf(`
-			This command deletes all entries from the specified %s dictionnaries.
+			This command deletes all entries from the specified %s dictionaries.
 		`, cs.Bold("custom")),
 		Example: heredoc.Doc(`
-			# Delete all entries from the "stopword" dictionnary
+			# Delete all entries from the "stopword" dictionary
 			$ algolia dictionary entries clear stopword
 
-			# Delete all entries from the "stopword" and "plural" dictionnaries
+			# Delete all entries from the "stopword" and "plural" dictionaries
 			$ algolia dictionary entries clear stopword plural
 
-			# Delete all entries from all dictionnaries
+			# Delete all entries from all dictionaries
 			$ algolia dictionary entries clear --all
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.All && len(args) > 0 || !opts.All && len(args) == 0 {
-				return cmdutil.FlagErrorf("Either specify dictionnaries' names or use --all to clear all dictionnaries")
+				return cmdutil.FlagErrorf("Either specify dictionaries' names or use --all to clear all dictionaries")
 			}
 
 			if opts.All {
-				opts.Dictionnaries = []search.DictionaryName{search.Stopwords, search.Plurals, search.Compounds}
+				opts.Dictionaries = []search.DictionaryName{search.Stopwords, search.Plurals, search.Compounds}
 			} else {
-				opts.Dictionnaries = make([]search.DictionaryName, len(args))
-				for i, dictionnary := range args {
-					opts.Dictionnaries[i] = search.DictionaryName(dictionnary)
+				opts.Dictionaries = make([]search.DictionaryName, len(args))
+				for i, dictionary := range args {
+					opts.Dictionaries[i] = search.DictionaryName(dictionary)
 				}
 			}
 
@@ -95,7 +95,7 @@ func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "skip confirmation prompt")
-	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "clear all dictionnaries")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "clear all dictionaries")
 
 	return cmd
 }
@@ -108,16 +108,16 @@ func runClearCmd(opts *ClearOptions) error {
 		return err
 	}
 
-	dictionaries := opts.Dictionnaries
+	dictionaries := opts.Dictionaries
 	dictionariesNames := make([]string, len(dictionaries))
 	dictionariesCustomEntriesNb := make([]int, len(dictionaries))
-	for i, dictionnary := range dictionaries {
-		nbCustomEntries, err := customEntriesNb(client, dictionnary)
+	for i, dictionary := range dictionaries {
+		nbCustomEntries, err := customEntriesNb(client, dictionary)
 		if err != nil {
 			return err
 		}
 		dictionariesCustomEntriesNb[i] = nbCustomEntries
-		dictionariesNames[i] = string(dictionnary)
+		dictionariesNames[i] = string(dictionary)
 	}
 
 	totalEntries := 0
@@ -157,8 +157,8 @@ func runClearCmd(opts *ClearOptions) error {
 	return nil
 }
 
-func customEntriesNb(client *search.Client, dictionnary search.DictionaryName) (int, error) {
-	res, err := client.SearchDictionaryEntries(dictionnary, "", opt.HitsPerPage(1000))
+func customEntriesNb(client *search.Client, dictionary search.DictionaryName) (int, error) {
+	res, err := client.SearchDictionaryEntries(dictionary, "", opt.HitsPerPage(1000))
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cmd/dictionary/entries/clear/clear_test.go
+++ b/pkg/cmd/dictionary/entries/clear/clear_test.go
@@ -30,7 +30,7 @@ func TestNewClearCmd(t *testing.T) {
 			wantsErr: true,
 			wantsOpts: ClearOptions{
 				DoConfirm: true,
-				Dictionnaries: []search.DictionaryName{
+				Dictionaries: []search.DictionaryName{
 					search.Plurals,
 				},
 			},
@@ -42,7 +42,7 @@ func TestNewClearCmd(t *testing.T) {
 			wantsErr: false,
 			wantsOpts: ClearOptions{
 				DoConfirm: false,
-				Dictionnaries: []search.DictionaryName{
+				Dictionaries: []search.DictionaryName{
 					search.Plurals,
 				},
 			},
@@ -54,7 +54,7 @@ func TestNewClearCmd(t *testing.T) {
 			wantsErr: false,
 			wantsOpts: ClearOptions{
 				DoConfirm: true,
-				Dictionnaries: []search.DictionaryName{
+				Dictionaries: []search.DictionaryName{
 					search.Stopwords,
 					search.Plurals,
 					search.Compounds,
@@ -68,7 +68,7 @@ func TestNewClearCmd(t *testing.T) {
 			wantsErr: true,
 			wantsOpts: ClearOptions{
 				DoConfirm: false,
-				Dictionnaries: []search.DictionaryName{
+				Dictionaries: []search.DictionaryName{
 					search.Plurals,
 				},
 			},
@@ -116,7 +116,7 @@ func TestNewClearCmd(t *testing.T) {
 			assert.Equal(t, "", stdout.String())
 			assert.Equal(t, "", stderr.String())
 
-			assert.Equal(t, tt.wantsOpts.Dictionnaries, opts.Dictionnaries)
+			assert.Equal(t, tt.wantsOpts.Dictionaries, opts.Dictionaries)
 			assert.Equal(t, tt.wantsOpts.DoConfirm, opts.DoConfirm)
 		})
 	}

--- a/pkg/cmd/dictionary/entries/delete/delete.go
+++ b/pkg/cmd/dictionary/entries/delete/delete.go
@@ -21,8 +21,8 @@ type DeleteOptions struct {
 
 	SearchClient func() (*search.Client, error)
 
-	Dictionnary search.DictionaryName
-	ObjectIDs   []string
+	Dictionary search.DictionaryName
+	ObjectIDs  []string
 
 	DoConfirm bool
 }
@@ -56,7 +56,7 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		`),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Dictionnary = search.DictionaryName(args[0])
+			opts.Dictionary = search.DictionaryName(args[0])
 			if !confirm {
 				if !opts.IO.CanPrompt() {
 					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
@@ -89,7 +89,7 @@ func runDeleteCmd(opts *DeleteOptions) error {
 
 	if opts.DoConfirm {
 		var confirmed bool
-		err = prompt.Confirm(fmt.Sprintf("Delete the %s from %s?", pluralizeEntry(len(opts.ObjectIDs)), opts.Dictionnary), &confirmed)
+		err = prompt.Confirm(fmt.Sprintf("Delete the %s from %s?", pluralizeEntry(len(opts.ObjectIDs)), opts.Dictionary), &confirmed)
 		if err != nil {
 			return fmt.Errorf("failed to prompt: %w", err)
 		}
@@ -98,14 +98,14 @@ func runDeleteCmd(opts *DeleteOptions) error {
 		}
 	}
 
-	_, err = client.DeleteDictionaryEntries(opts.Dictionnary, opts.ObjectIDs)
+	_, err = client.DeleteDictionaryEntries(opts.Dictionary, opts.ObjectIDs)
 	if err != nil {
 		return err
 	}
 
 	cs := opts.IO.ColorScheme()
 	if opts.IO.IsStdoutTTY() {
-		fmt.Fprintf(opts.IO.Out, "%s Successfully deleted %s from %s\n", cs.SuccessIcon(), pluralizeEntry(len(opts.ObjectIDs)), opts.Dictionnary)
+		fmt.Fprintf(opts.IO.Out, "%s Successfully deleted %s from %s\n", cs.SuccessIcon(), pluralizeEntry(len(opts.ObjectIDs)), opts.Dictionary)
 	}
 
 	return nil

--- a/pkg/cmd/dictionary/entries/delete/delete_test.go
+++ b/pkg/cmd/dictionary/entries/delete/delete_test.go
@@ -35,8 +35,8 @@ func TestNewDeleteCmd(t *testing.T) {
 			tty:      true,
 			wantsErr: false,
 			wantsOpts: DeleteOptions{
-				DoConfirm:   false,
-				Dictionnary: "plural",
+				DoConfirm:  false,
+				Dictionary: "plural",
 				ObjectIDs: []string{
 					"1",
 				},
@@ -48,8 +48,8 @@ func TestNewDeleteCmd(t *testing.T) {
 			tty:      true,
 			wantsErr: false,
 			wantsOpts: DeleteOptions{
-				DoConfirm:   true,
-				Dictionnary: "plural",
+				DoConfirm:  true,
+				Dictionary: "plural",
 				ObjectIDs: []string{
 					"1",
 				},
@@ -61,8 +61,8 @@ func TestNewDeleteCmd(t *testing.T) {
 			tty:      false,
 			wantsErr: false,
 			wantsOpts: DeleteOptions{
-				DoConfirm:   false,
-				Dictionnary: "plural",
+				DoConfirm:  false,
+				Dictionary: "plural",
 				ObjectIDs: []string{
 					"1",
 					"2",
@@ -103,7 +103,7 @@ func TestNewDeleteCmd(t *testing.T) {
 			assert.Equal(t, "", stdout.String())
 			assert.Equal(t, "", stderr.String())
 
-			assert.Equal(t, tt.wantsOpts.Dictionnary, opts.Dictionnary)
+			assert.Equal(t, tt.wantsOpts.Dictionary, opts.Dictionary)
 			assert.Equal(t, tt.wantsOpts.ObjectIDs, opts.ObjectIDs)
 			assert.Equal(t, tt.wantsOpts.DoConfirm, opts.DoConfirm)
 		})
@@ -112,17 +112,17 @@ func TestNewDeleteCmd(t *testing.T) {
 
 func Test_runDeleteCmd(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		dictionnary string
-		objectIDs   []string
-		isTTY       bool
-		wantOut     string
+		name       string
+		cli        string
+		dictionary string
+		objectIDs  []string
+		isTTY      bool
+		wantOut    string
 	}{
 		{
-			name:        "single object-id, no TTY",
-			cli:         "plural --object-ids 1 --confirm",
-			dictionnary: "plural",
+			name:       "single object-id, no TTY",
+			cli:        "plural --object-ids 1 --confirm",
+			dictionary: "plural",
 			objectIDs: []string{
 				"1",
 			},
@@ -130,9 +130,9 @@ func Test_runDeleteCmd(t *testing.T) {
 			wantOut: "",
 		},
 		{
-			name:        "single object-id, TTY",
-			cli:         "plural --object-ids 1 --confirm",
-			dictionnary: "plural",
+			name:       "single object-id, TTY",
+			cli:        "plural --object-ids 1 --confirm",
+			dictionary: "plural",
 			objectIDs: []string{
 				"1",
 			},
@@ -140,9 +140,9 @@ func Test_runDeleteCmd(t *testing.T) {
 			wantOut: "✓ Successfully deleted 1 entry from plural\n",
 		},
 		{
-			name:        "multiple object-ids, TTY",
-			cli:         "plural --object-ids 1,2 --confirm",
-			dictionnary: "plural",
+			name:       "multiple object-ids, TTY",
+			cli:        "plural --object-ids 1,2 --confirm",
+			dictionary: "plural",
 			objectIDs: []string{
 				"1",
 				"2",
@@ -158,9 +158,9 @@ func Test_runDeleteCmd(t *testing.T) {
 
 			// test is flaky since there's no guarantee of obtaining the right object using a search by objectID
 			for _, id := range tt.objectIDs {
-				r.Register(httpmock.REST("GET", fmt.Sprintf("1/dictionaries/%s/search?query=%s", tt.dictionnary, id)), httpmock.JSONResponse(search.SearchDictionariesRes{}))
+				r.Register(httpmock.REST("GET", fmt.Sprintf("1/dictionaries/%s/search?query=%s", tt.dictionary, id)), httpmock.JSONResponse(search.SearchDictionariesRes{}))
 			}
-			r.Register(httpmock.REST("POST", fmt.Sprintf("1/dictionaries/%s/batch", tt.dictionnary)), httpmock.JSONResponse(search.TaskStatusRes{}))
+			r.Register(httpmock.REST("POST", fmt.Sprintf("1/dictionaries/%s/batch", tt.dictionary)), httpmock.JSONResponse(search.TaskStatusRes{}))
 
 			f, out := test.NewFactory(tt.isTTY, &r, nil, "")
 			cmd := NewDeleteCmd(f, nil)

--- a/pkg/cmd/dictionary/entries/entries.go
+++ b/pkg/cmd/dictionary/entries/entries.go
@@ -10,7 +10,7 @@ import (
 	"github.com/algolia/cli/pkg/cmdutil"
 )
 
-// NewEntriesCmd returns a new command for dictionnaries' entries.
+// NewEntriesCmd returns a new command for dictionaries' entries.
 func NewEntriesCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "entries",

--- a/pkg/cmd/dictionary/settings/settings.go
+++ b/pkg/cmd/dictionary/settings/settings.go
@@ -8,7 +8,7 @@ import (
 	"github.com/algolia/cli/pkg/cmdutil"
 )
 
-// NewSettingsCmd returns a new command for dictionnaries' entries.
+// NewSettingsCmd returns a new command for dictionaries' entries.
 func NewSettingsCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "settings",

--- a/pkg/cmd/dictionary/shared/constants.go
+++ b/pkg/cmd/dictionary/shared/constants.go
@@ -4,7 +4,7 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 )
 
-// EntryType represents the type of an entry in a dictionnary.
+// EntryType represents the type of an entry in a dictionary.
 // It can be either a custom entry or a standard entry.
 type EntryType string
 type DictionaryType int
@@ -21,14 +21,14 @@ type DictionaryEntry struct {
 }
 
 const (
-	// CustomEntryType is the type of a custom entry in a dictionnary (i.e. added by the user).
+	// CustomEntryType is the type of a custom entry in a dictionary (i.e. added by the user).
 	CustomEntryType EntryType = "custom"
-	// StandardEntryType is the type of a standard entry in a dictionnary (i.e. added by Algolia).
+	// StandardEntryType is the type of a standard entry in a dictionary (i.e. added by Algolia).
 	StandardEntryType EntryType = "standard"
 )
 
 var (
-	// DictionaryNames returns the list of available dictionnaries.
+	// DictionaryNames returns the list of available dictionaries.
 	DictionaryNames = func() []string {
 		return []string{
 			string(search.Stopwords),


### PR DESCRIPTION
This PR adds rendering the sub-subcommands from `algolia index config` and `algolia dictionary {settings,entries}` correctly. 

This PR also corrects the numbering of the commands in the reference, so that they appear alphabetically, like in the terminal. 

The actual rendering of the YAML will be done in the documentation repo. 

[DEX-810]

[DEX-810]: https://algolia.atlassian.net/browse/DEX-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ