### PR TITLE
feat(automation): new world doc pr creation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,24 +2,23 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.19
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -51,4 +51,6 @@ jobs:
           GIT_COMMITTER_EMAIL: noreply@algolia.com
           GIT_AUTHOR_EMAIL: noreply@algolia.com
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-        run: make docs-pr
+        run: |
+          make docs-pr
+          make VARIATON=new docs-pr

--- a/Makefile
+++ b/Makefile
@@ -9,27 +9,42 @@ test:
 	go test ./... -p 1
 .PHONY: test
 
-## Build & publish the documentation
+## Build & publish the old documentation
+VARIATION ?= old
+ifeq ($(VARIATION),old)
+DOCS_FOLDER = docs
+DOCS_GENERATED_PATH = app_data/cli/commands
+DOCS_REPO_URL = https://github.com/algolia/doc.git
+DOCS_BRANCH = master
+DOCS_EXTENSION = yml
+else ifeq ($(VARIATION),new)
+DOCS_FOLDER = new-world-docs
+DOCS_GENERATED_PATH = apps/docs/content/pages/tools/cli/commands
+DOCS_REPO_URL = https://github.com/algolia/new-world-docs.git
+DOCS_BRANCH = main
+DOCS_EXTENSION = mdx
+endif
+
 docs:
-	git clone https://github.com/algolia/doc.git "$@"
+	git clone $(DOCS_REPO_URL) "$@"
 
 .PHONY: docs-commands-data
 docs-commands-data: docs
-	git -C docs pull
-	git -C docs checkout master
-	git -C docs rm 'app_data/cli/commands/*.yml' 2>/dev/null || true
-	go run ./cmd/docs --app_data-path docs/app_data/cli/commands
-	git -C docs add 'app_data/cli/commands/*.yml'
+	git -C $(DOCS_FOLDER) pull
+	git -C $(DOCS_FOLDER) checkout $(DOCS_BRANCH)
+	git -C $(DOCS_FOLDER) rm '$(DOCS_GENERATED_PATH)/*.$(DOCS_EXTENSION)' 2>/dev/null || true
+	go run ./cmd/docs --app_data-path $(DOCS_FOLDER)/$(DOCS_GENERATED_PATH) --target $(VARIATION)
+	git -C $(DOCS_FOLDER) add '$(DOCS_GENERATED_PATH)/*.$(DOCS_EXTENSION)'
 
 .PHONY: docs-pr
 docs-pr: docs-commands-data
 ifndef GITHUB_REF
 	$(error GITHUB_REF is not set)
 endif
-	git -C docs checkout -B feat/cli-'$(GITHUB_REF:refs/tags/v%=%)'
-	git -C docs commit -m 'feat: update cli commands data for $(GITHUB_REF:refs/tags/v%=%) version' || true
-	git -C docs push --set-upstream origin feat/cli-'$(GITHUB_REF:refs/tags/v%=%)'
-	cd docs; gh pr create -f -b "Changelog: https://github.com/algolia/cli/releases/tag/$(GITHUB_REF:refs/tags/v%=%)"
+	git -C $(DOCS_FOLDER) checkout -B feat/cli-'$(GITHUB_REF:refs/tags/v%=%)'
+	git -C $(DOCS_FOLDER) commit -m 'feat: update cli commands data for $(GITHUB_REF:refs/tags/v%=%) version' || true
+	git -C $(DOCS_FOLDER) push --set-upstream origin feat/cli-'$(GITHUB_REF:refs/tags/v%=%)'
+	cd $(DOCS_FOLDER); gh pr create -f -b "Changelog: https://github.com/algolia/cli/releases/tag/$(GITHUB_REF:refs/tags/v%=%)"
 
 ## Create a new PR (or update the existing one) to update the API specs
 api-specs-pr:

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -60,7 +60,7 @@ func run(args []string) error {
 			return err
 		}
 	} else {
-		if err := docs.GenMdxFile(rootCmd, *dir); err != nil {
+		if err := docs.GenMdxTree(rootCmd, *dir); err != nil {
 			return err
 		}
 	}

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -25,6 +25,11 @@ func run(args []string) error {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	dir := flags.StringP("app_data-path", "", "", "Path directory where you want generate documentation data files")
 	help := flags.BoolP("help", "h", false, "Help about any command")
+	target := flags.StringP("target", "T", "old", "target old or new documentation website")
+
+	if *target != "old" && *target != "new" {
+		return fmt.Errorf("error: --destination can only be 'old' or 'new' ('old' by default)")
+	}
 
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -50,8 +55,14 @@ func run(args []string) error {
 		return err
 	}
 
-	if err := docs.GenYamlTree(rootCmd, *dir); err != nil {
-		return err
+	if *target == "old" {
+		if err := docs.GenYamlTree(rootCmd, *dir); err != nil {
+			return err
+		}
+	} else {
+		if err := docs.GenMdxFile(rootCmd, *dir); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1,0 +1,147 @@
+package docs
+
+import (
+	"strings"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type Command struct {
+	Name        string
+	Description string
+	Usage       string
+	Aliases     []string
+	Examples    string
+	Slug        string
+	RunInWebCLI bool
+
+	Flags map[string][]Flag
+
+	SubCommands []Command
+}
+
+type Flag struct {
+	Name        string
+	Shorthand   string
+	Description string
+	Default     string
+}
+
+func newFlag(flag *pflag.Flag) Flag {
+	return Flag{
+		Name:      flag.Name,
+		Shorthand: flag.Shorthand,
+		// Add two spaces before each newline to force a newline in markdown
+		Description: strings.ReplaceAll(flag.Usage, "\n", "  \n"),
+		Default:     flag.DefValue,
+	}
+}
+
+func newFlags(flagSet *pflag.FlagSet) []Flag {
+	flags := make([]Flag, 0)
+	flagSet.VisitAll(func(flag *pflag.Flag) {
+		flags = append(flags, newFlag(flag))
+	})
+	return flags
+}
+
+func newCommand(cmd *cobra.Command) Command {
+	categoryFlagSet := cmdutil.NewCategoryFlagSet(cmd.NonInheritedFlags())
+	command := Command{
+		Name:        cmd.CommandPath(),
+		Description: cmd.Short,
+		Usage:       cmd.UseLine(),
+		Aliases:     cmd.Aliases,
+		Examples:    cmd.Example,
+		RunInWebCLI: false,
+	}
+	if value, ok := cmd.Annotations["runInWebCLI"]; ok && value != "" {
+		command.RunInWebCLI = true
+	}
+
+	flags := make(map[string][]Flag)
+
+	if len(categoryFlagSet.Categories) > 0 {
+		for _, categoryName := range categoryFlagSet.SortedCategoryNames() {
+			flags[categoryName] = newFlags(categoryFlagSet.Categories[categoryName])
+		}
+		if categoryFlagSet.Others.HasAvailableFlags() {
+			flags["Other flags"] = newFlags(categoryFlagSet.Others)
+		}
+	} else {
+		if categoryFlagSet.Others.HasAvailableFlags() {
+			flags["Flags"] = newFlags(categoryFlagSet.Others)
+		}
+	}
+
+	if categoryFlagSet.Print.HasAvailableFlags() {
+		flags["Output formatting flags"] = newFlags(categoryFlagSet.Print)
+
+	}
+	command.Flags = flags
+
+	return command
+}
+
+func getCommands(cmd *cobra.Command) []Command {
+	var commands []Command
+	for _, c := range cmd.Commands() {
+		if c.Hidden || c.Name() == "help" {
+			continue
+		}
+		command := newCommand(c)
+		if c.HasAvailableSubCommands() {
+			for _, s := range c.Commands() {
+				sub := newCommand(s)
+				if s.HasAvailableSubCommands() {
+					for _, sus := range s.Commands() {
+						sub.SubCommands = append(sub.SubCommands, newCommand(sus))
+					}
+				}
+				command.SubCommands = append(command.SubCommands, sub)
+			}
+		}
+		commands = append(commands, command)
+	}
+
+	return commands
+}
+
+type Example struct {
+	Desc          string
+	Code          string
+	WebCLICommand string
+}
+
+func (cmd Command) ExamplesList() []Example {
+	var examples []Example
+	examplesRaw := strings.Split(cmd.Examples, "#")
+	for _, example := range examplesRaw {
+		example = strings.TrimSpace(example)
+		if len(example) == 0 {
+			continue
+		}
+		exampleLines := strings.Split(example, "\n")
+
+		code := strings.ReplaceAll(exampleLines[1], "$", "")
+		code = strings.TrimSpace(code)
+
+		formattedExample := Example{
+			Desc: strings.Replace(exampleLines[0], "#", "", 1),
+			Code: code,
+		}
+		if cmd.RunInWebCLI &&
+			!strings.Contains(code, ">") &&
+			!strings.Contains(code, "<") &&
+			!strings.Contains(code, "output") &&
+			!strings.Contains(code, "-F") &&
+			!strings.Contains(code, "|") {
+			formattedExample.WebCLICommand = strings.ReplaceAll(code, `"`, `\"`)
+		}
+
+		examples = append(examples, formattedExample)
+	}
+	return examples
+}

--- a/internal/docs/mdx.go
+++ b/internal/docs/mdx.go
@@ -10,36 +10,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func GenMdxFile(cmd *cobra.Command, dir string) error {
-	for _, c := range cmd.Commands() {
-		if c.Hidden || c.Name() == "help" {
-			continue
-		}
-		command := newCommand(c)
-		command.Slug = strings.ReplaceAll(command.Name, " ", "-")
-		filename := filepath.Join(dir, fmt.Sprintf("%s.mdx", command.Slug))
+func GenMdxTree(cmd *cobra.Command, dir string) error {
+	tpl, err := template.New("mdx.tpl").Funcs(template.FuncMap{
+		"getExamples": func(cmd Command) []Example {
+			return cmd.ExamplesList()
+		},
+	}).ParseFiles("internal/docs/mdx.tpl")
+	if err != nil {
+		return err
+	}
+
+	commands := getCommands(cmd)
+
+	for _, c := range commands {
+		c.Slug = strings.ReplaceAll(c.Name, " ", "-")
+		filename := filepath.Join(dir, fmt.Sprintf("%s.mdx", c.Slug))
 		file, err := os.Create(filename)
 		if err != nil {
 			return err
 		}
 
-		tpl, err := template.ParseFiles("internal/docs/mdx.tpl")
-		if err != nil {
-			return err
-		}
-
-		if c.HasAvailableSubCommands() {
-			for _, s := range c.Commands() {
-				sub := newCommand(s)
-				if s.HasAvailableSubCommands() {
-					for _, sus := range s.Commands() {
-						sub.SubCommands = append(sub.SubCommands, newCommand(sus))
-					}
-				}
-				command.SubCommands = append(command.SubCommands, sub)
-			}
-		}
-		err = tpl.Execute(file, command)
+		err = tpl.Execute(file, c)
 		if err != nil {
 			return err
 		}

--- a/internal/docs/mdx.go
+++ b/internal/docs/mdx.go
@@ -1,0 +1,49 @@
+package docs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+func GenMdxFile(cmd *cobra.Command, dir string) error {
+	for _, c := range cmd.Commands() {
+		if c.Hidden || c.Name() == "help" {
+			continue
+		}
+		command := newCommand(c)
+		command.Slug = strings.ReplaceAll(command.Name, " ", "-")
+		filename := filepath.Join(dir, fmt.Sprintf("%s.mdx", command.Slug))
+		file, err := os.Create(filename)
+		if err != nil {
+			return err
+		}
+
+		tpl, err := template.ParseFiles("internal/docs/mdx.tpl")
+		if err != nil {
+			return err
+		}
+
+		if c.HasAvailableSubCommands() {
+			for _, s := range c.Commands() {
+				sub := newCommand(s)
+				if s.HasAvailableSubCommands() {
+					for _, sus := range s.Commands() {
+						sub.SubCommands = append(sub.SubCommands, newCommand(sus))
+					}
+				}
+				command.SubCommands = append(command.SubCommands, sub)
+			}
+		}
+		err = tpl.Execute(file, command)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/docs/mdx.tpl
+++ b/internal/docs/mdx.tpl
@@ -16,8 +16,16 @@ slug: tools/cli/commands/{{ .Slug }}
 
 `{{ $subCommand.Usage }}`
 
-{{ if $subCommand.Examples }}### Examples{{ end }}
-{{ $subCommand.Examples }}
+{{ $examples := getExamples $subCommand }}
+{{ if $examples }}
+### Examples
+{{ range $example := $examples }}
+{{ $example.Desc }}
+
+```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+{{ $example.Code }}
+```
+{{ end }}{{ end }}
 {{ range $flagKey, $flagSlice := $subCommand.Flags }}
 {{ if $flagSlice }}### Flags {{ end }}
 {{ range $flag := $flagSlice }}
@@ -27,13 +35,19 @@ slug: tools/cli/commands/{{ .Slug }}
 {{ end }}
 {{ else }}
 ## {{ .Name }}
+
 ### Usage
 
 `{{ .Usage }}`
+{{ $examples := getExamples . }}
+{{ if $examples }}### Examples
+{{ range $example := $examples }}
+{{ $example.Desc }}
 
-{{ if .Examples }}
-### Examples
-{{ .Examples }}
+```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+{{ $example.Code }}
+```
+{{ end }}
 {{ end }}
 {{ range $flagKey, $flagSlice := .Flags }}
 ### {{ $flagKey }}

--- a/internal/docs/mdx.tpl
+++ b/internal/docs/mdx.tpl
@@ -1,0 +1,44 @@
+---
+navigation: "cli"
+title: |-
+{{ .Name }}
+description: |-
+{{ .Description }}
+slug: tools/cli/commands/{{ .Slug }}
+---
+{{ if .SubCommands }}
+{{ range $subCommand := .SubCommands }}
+## {{ $subCommand.Name }}
+
+{{ $subCommand.Description }}
+
+### Usage
+
+`{{ $subCommand.Usage }}`
+
+{{ if $subCommand.Examples }}### Examples{{ end }}
+{{ $subCommand.Examples }}
+{{ range $flagKey, $flagSlice := $subCommand.Flags }}
+{{ if $flagSlice }}### Flags {{ end }}
+{{ range $flag := $flagSlice }}
+- {{ if $flag.Shorthand }}`-{{ $flag.Shorthand }}`, {{ end }}`--{{ $flag.Name }}`: {{ $flag.Description }}
+{{ end }}
+{{ end }}
+{{ end }}
+{{ else }}
+## {{ .Name }}
+### Usage
+
+`{{ .Usage }}`
+
+{{ if .Examples }}
+### Examples
+{{ .Examples }}
+{{ end }}
+{{ range $flagKey, $flagSlice := .Flags }}
+### {{ $flagKey }}
+{{ range $flag := $flagSlice }}
+- {{ if $flag.Shorthand }}`-{{ $flag.Shorthand }}`, {{ end }}`--{{ $flag.Name }}`: {{ $flag.Description }}
+{{ end }}
+{{ end }}
+{{end}}

--- a/internal/docs/mdx.tpl
+++ b/internal/docs/mdx.tpl
@@ -6,8 +6,29 @@ description: |-
 {{ .Description }}
 slug: tools/cli/commands/{{ .Slug }}
 ---
-{{ if .SubCommands }}
-{{ range $subCommand := .SubCommands }}
+{{ if .SubCommands }}{{ range $subCommand := .SubCommands }}{{ if $subCommand.SubCommands }}{{ range $susCommand := $subCommand.SubCommands}}
+## {{ $susCommand.Name }}
+
+{{ $susCommand.Description }}
+
+### Usage
+
+`{{ $susCommand.Usage }}`
+
+{{ $examples := getExamples $susCommand }}{{ if $examples }}
+### Examples
+{{ range $example := $examples }}{{ $example.Desc }}
+
+```sh 
+{{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+{{ $example.Code }}
+```
+{{ end }}{{ end }}{{ range $flagKey, $flagSlice := $susCommand.Flags }}{{ if $flagSlice }}
+### Flags 
+{{ range $flag := $flagSlice }}
+- {{ if $flag.Shorthand }}`-{{ $flag.Shorthand }}`, {{ end }}`--{{ $flag.Name }}`: {{ $flag.Description }}
+{{ end }}{{ end }}{{ end }}{{ end }}
+{{ else }}
 ## {{ $subCommand.Name }}
 
 {{ $subCommand.Description }}
@@ -22,37 +43,36 @@ slug: tools/cli/commands/{{ .Slug }}
 {{ range $example := $examples }}
 {{ $example.Desc }}
 
-```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+```sh 
+{{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
 {{ $example.Code }}
 ```
-{{ end }}{{ end }}
+{{ end }}
+{{ end }}
+
 {{ range $flagKey, $flagSlice := $subCommand.Flags }}
-{{ if $flagSlice }}### Flags {{ end }}
+{{ if $flagSlice }}
+### Flags 
 {{ range $flag := $flagSlice }}
 - {{ if $flag.Shorthand }}`-{{ $flag.Shorthand }}`, {{ end }}`--{{ $flag.Name }}`: {{ $flag.Description }}
-{{ end }}
-{{ end }}
-{{ end }}
-{{ else }}
-## {{ .Name }}
+{{ end }}{{ end }}{{ end }}{{ end}}{{ end }}
+{{ else }}## {{ .Name }}
 
 ### Usage
 
 `{{ .Usage }}`
-{{ $examples := getExamples . }}
-{{ if $examples }}### Examples
+{{ $examples := getExamples . }}{{ if $examples }}
+### Examples
 {{ range $example := $examples }}
 {{ $example.Desc }}
 
-```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+```sh 
+{{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
 {{ $example.Code }}
 ```
-{{ end }}
-{{ end }}
+{{ end }}{{ end }}
 {{ range $flagKey, $flagSlice := .Flags }}
 ### {{ $flagKey }}
 {{ range $flag := $flagSlice }}
 - {{ if $flag.Shorthand }}`-{{ $flag.Shorthand }}`, {{ end }}`--{{ $flag.Name }}`: {{ $flag.Description }}
-{{ end }}
-{{ end }}
-{{end}}
+{{ end }}{{ end }}{{ end }}

--- a/internal/docs/yaml.go
+++ b/internal/docs/yaml.go
@@ -6,104 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 )
 
-type Command struct {
-	Name        string
-	Description string
-	Usage       string
-	Aliases     []string
-	Examples    string
-	Slug        string
-
-	Flags map[string][]Flag
-
-	SubCommands []Command
-}
-
-type Flag struct {
-	Name        string
-	Shorthand   string
-	Description string
-	Default     string
-}
-
-func newFlag(flag *pflag.Flag) Flag {
-	return Flag{
-		Name:      flag.Name,
-		Shorthand: flag.Shorthand,
-		// Add two spaces before each newline to force a newline in markdown
-		Description: strings.ReplaceAll(flag.Usage, "\n", "  \n"),
-		Default:     flag.DefValue,
-	}
-}
-
-func newFlags(flagSet *pflag.FlagSet) []Flag {
-	flags := make([]Flag, 0)
-	flagSet.VisitAll(func(flag *pflag.Flag) {
-		flags = append(flags, newFlag(flag))
-	})
-	return flags
-}
-
-func newCommand(cmd *cobra.Command) Command {
-	categoryFlagSet := cmdutil.NewCategoryFlagSet(cmd.NonInheritedFlags())
-	command := Command{
-		Name:        cmd.CommandPath(),
-		Description: cmd.Short,
-		Usage:       cmd.UseLine(),
-		Aliases:     cmd.Aliases,
-		Examples:    cmd.Example,
-	}
-
-	flags := make(map[string][]Flag)
-
-	if len(categoryFlagSet.Categories) > 0 {
-		for _, categoryName := range categoryFlagSet.SortedCategoryNames() {
-			flags[categoryName] = newFlags(categoryFlagSet.Categories[categoryName])
-		}
-		if categoryFlagSet.Others.HasAvailableFlags() {
-			flags["Other flags"] = newFlags(categoryFlagSet.Others)
-		}
-	} else {
-		if categoryFlagSet.Others.HasAvailableFlags() {
-			flags["Flags"] = newFlags(categoryFlagSet.Others)
-		}
-	}
-
-	if categoryFlagSet.Print.HasAvailableFlags() {
-		flags["Output formatting flags"] = newFlags(categoryFlagSet.Print)
-
-	}
-	command.Flags = flags
-
-	return command
-}
-
 func GenYamlTree(cmd *cobra.Command, dir string) error {
-	var commands []Command
-	for _, c := range cmd.Commands() {
-		if c.Hidden || c.Name() == "help" {
-			continue
-		}
-		command := newCommand(c)
-		if c.HasAvailableSubCommands() {
-			for _, s := range c.Commands() {
-				sub := newCommand(s)
-				if s.HasAvailableSubCommands() {
-					for _, sus := range s.Commands() {
-						sub.SubCommands = append(sub.SubCommands, newCommand(sus))
-					}
-				}
-				command.SubCommands = append(command.SubCommands, sub)
-			}
-		}
-		commands = append(commands, command)
-	}
+	commands := getCommands(cmd)
 
 	for _, c := range commands {
 		command_path := strings.ReplaceAll(c.Name, " ", "_")

--- a/internal/docs/yaml.go
+++ b/internal/docs/yaml.go
@@ -18,6 +18,7 @@ type Command struct {
 	Usage       string
 	Aliases     []string
 	Examples    string
+	Slug        string
 
 	Flags map[string][]Flag
 

--- a/pkg/cmd/indices/list/list.go
+++ b/pkg/cmd/indices/list/list.go
@@ -43,6 +43,9 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runListCmd(opts)
 		},
+		Annotations: map[string]string{
+			"runInWebCLI": "true",
+		},
 	}
 
 	opts.PrintFlags.AddFlags(cmd)

--- a/pkg/cmd/search/search.go
+++ b/pkg/cmd/search/search.go
@@ -41,6 +41,9 @@ func NewSearchCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:              validators.ExactArgs(1),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
 		Long:              `Search for objects in your index.`,
+		Annotations: map[string]string{
+			"runInWebCLI": "true",
+		},
 		Example: heredoc.Doc(`
 			# Search for objects in the "BOOKS" index matching the query "tolkien"
 			$ algolia search BOOKS --query "tolkien"


### PR DESCRIPTION
### [DEX-1021](https://algolia.atlassian.net/browse/DEX-1021)

This PR create a command to generate a `new-world-docs` PR that'll update the `.mdx` files for the CLI documentation.

## How to test?
 
```sh
go run ./cmd/docs --app_data-path docs/app_data/cli/commands --target new
```

It will output the files in at `docs/app_data/cli/commands`

## Refinement

Summary of our discussion with @clemfromspace:

- We'll add annotation (`runInWebCli`) to commands with `web CLI` enabled in `new-world-docs`
- Because there's differences between CLI examples and the ones run with the `web CLI`, we'll standardize all examples with the `new-world-docs`/`webCLI` (in a future PR)
- Examples with output or pipe symbols will automatically be non-runnable

[DEX-1021]: https://algolia.atlassian.net/browse/DEX-1021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ