### PR TITLE
fix(gen) Escape backticks during the flags generation

### DIFF
--- a/pkg/gen/gen_flags.go
+++ b/pkg/gen/gen_flags.go
@@ -199,6 +199,9 @@ func getFlag(param *openapi3.Schema) *SpecFlag {
 
 // getDescription returns the description for the given parameter.
 func getDescription(param *openapi3.Schema) string {
+	// Escape backticks
+	param.Description = strings.ReplaceAll(param.Description, "`", "`+\"`\"+`")
+
 	if param.Enum != nil {
 		choices := make([]string, len(param.Enum))
 		for i, e := range param.Enum {


### PR DESCRIPTION
The newly added backticks in the Open API specs was crashing the auto-generated flags generation.