### PR TITLE
feat(examples): matching new world docs indexes and dataset [DEX-1048]

### DIFF
--- a/internal/docs/mdx.tpl
+++ b/internal/docs/mdx.tpl
@@ -1,9 +1,9 @@
 ---
 navigation: "cli"
 title: |-
-{{ .Name }}
+  {{ .Name }}
 description: |-
-{{ .Description }}
+  {{ .Description }}
 slug: tools/cli/commands/{{ .Slug }}
 ---
 {{ if .SubCommands }}{{ range $subCommand := .SubCommands }}{{ if $subCommand.SubCommands }}{{ range $susCommand := $subCommand.SubCommands}}
@@ -19,8 +19,7 @@ slug: tools/cli/commands/{{ .Slug }}
 ### Examples
 {{ range $example := $examples }}{{ $example.Desc }}
 
-```sh 
-{{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
 {{ $example.Code }}
 ```
 {{ end }}{{ end }}{{ range $flagKey, $flagSlice := $susCommand.Flags }}{{ if $flagSlice }}
@@ -43,8 +42,7 @@ slug: tools/cli/commands/{{ .Slug }}
 {{ range $example := $examples }}
 {{ $example.Desc }}
 
-```sh 
-{{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
 {{ $example.Code }}
 ```
 {{ end }}
@@ -66,8 +64,7 @@ slug: tools/cli/commands/{{ .Slug }}
 {{ range $example := $examples }}
 {{ $example.Desc }}
 
-```sh 
-{{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
 {{ $example.Code }}
 ```
 {{ end }}{{ end }}

--- a/pkg/cmd/apikeys/create/create.go
+++ b/pkg/cmd/apikeys/create/create.go
@@ -42,11 +42,11 @@ func NewCreateCmd(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		Short: "Create a new API key",
 		Long:  `Create a new API key with the provided parameters.`,
 		Example: heredoc.Doc(`
-			# Create a new API key targeting the index "foo", with the "search" and "browse" ACL and a description
-			$ algolia apikeys create --indices foo --acl search,browse --description "Search & Browse API Key"
+			# Create a new API key targeting the index "MOVIES", with the "search" and "browse" ACL and a description
+			$ algolia apikeys create --indices MOVIES --acl search,browse --description "Search & Browse API Key"
 
-			# Create a new API key targeting the indices "foo" and "bar", with the "http://foo.com" referer, with a validity of 1 hour and a description
-			$ algolia apikeys create -i foo,bar --acl search -r "http://foo.com" --u 1h -d "Search-only API Key for foo & bar"
+			# Create a new API key targeting the indices "MOVIES" and "SERIES", with the "https://netflix.com" referer, with a validity of 1 hour and a description
+			$ algolia apikeys create -i MOVIES,SERIES --acl search -r "https://netflix.com" --u 1h -d "Search-only API Key for MOVIES & SERIES"
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runF != nil {

--- a/pkg/cmd/apikeys/create/create.go
+++ b/pkg/cmd/apikeys/create/create.go
@@ -45,8 +45,8 @@ func NewCreateCmd(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			# Create a new API key targeting the index "MOVIES", with the "search" and "browse" ACL and a description
 			$ algolia apikeys create --indices MOVIES --acl search,browse --description "Search & Browse API Key"
 
-			# Create a new API key targeting the indices "MOVIES" and "SERIES", with the "https://netflix.com" referer, with a validity of 1 hour and a description
-			$ algolia apikeys create -i MOVIES,SERIES --acl search -r "https://netflix.com" --u 1h -d "Search-only API Key for MOVIES & SERIES"
+			# Create a new API key targeting the indices "MOVIES" and "SERIES", with the "https://example.com" referer, with a validity of 1 hour and a description
+			$ algolia apikeys create -i MOVIES,SERIES --acl search -r "https://example.com" --u 1h -d "Search-only API Key for MOVIES & SERIES"
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runF != nil {
@@ -60,19 +60,19 @@ func NewCreateCmd(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().StringSliceVar(&opts.ACL, "acl", nil, heredoc.Docf(`
 		ACL of the API Key.
 
-		%[1]ssearch%[1]s: allowed to perform search operations.
-		%[1]sbrowse%[1]s: allowed to retrieve all index data with the browse endpoint.
-		%[1]saddObject%[1]s: allowed to add or update a records in the index.
-		%[1]sdeleteObject%[1]s: allowed to delete an existing record.
-		%[1]slistIndexes%[1]s: allowed to get a list of all existing indices.
-		%[1]sdeleteIndex%[1]s: allowed to delete an index.
-		%[1]ssettings%[1]s: allowed to read all index settings.
-		%[1]seditSettings%[1]s: allowed to update all index settings.
-		%[1]sanalytics%[1]s: allowed to retrieve data with the Analytics API.
-		%[1]srecommendation%[1]s: allowed to interact with the Recommendation API.
-		%[1]susage%[1]s: allowed to retrieve data with the Usage API.
-		%[1]slogs%[1]s: allowed to query the logs.
-		%[1]sseeUnretrievableAttributes%[1]s: allowed to retrieve unretrievableAttributes for all operations that return records.
+			%[1]ssearch%[1]s: allowed to perform search operations.
+			%[1]sbrowse%[1]s: allowed to retrieve all index data with the browse endpoint.
+			%[1]saddObject%[1]s: allowed to add or update a records in the index.
+			%[1]sdeleteObject%[1]s: allowed to delete an existing record.
+			%[1]slistIndexes%[1]s: allowed to get a list of all existing indices.
+			%[1]sdeleteIndex%[1]s: allowed to delete an index.
+			%[1]ssettings%[1]s: allowed to read all index settings.
+			%[1]seditSettings%[1]s: allowed to update all index settings.
+			%[1]sanalytics%[1]s: allowed to retrieve data with the Analytics API.
+			%[1]srecommendation%[1]s: allowed to interact with the Recommendation API.
+			%[1]susage%[1]s: allowed to retrieve data with the Usage API.
+			%[1]slogs%[1]s: allowed to query the logs.
+			%[1]sseeUnretrievableAttributes%[1]s: allowed to retrieve unretrievableAttributes for all operations that return records.
 	`, "`"))
 
 	cmd.Flags().StringSliceVarP(&opts.Indices, "indices", "i", nil, heredoc.Docf(`

--- a/pkg/cmd/crawler/crawl/crawl.go
+++ b/pkg/cmd/crawler/crawl/crawl.go
@@ -43,14 +43,14 @@ func NewCrawlCmd(f *cmdutil.Factory, runF func(*CrawlOptions) error) *cobra.Comm
 			The generated records are pushed to the live index if there's no ongoing reindex, and to the temporary index otherwise.
 		`),
 		Example: heredoc.Doc(`
-			# Crawl the URLs "https://www.netflix.com" and "https://www.primevideo.com/" for the crawler with the ID "my-crawler"
-			$ algolia crawler crawl my-crawler --urls https://www.netflix.com,https://www.primevideo.com/
+			# Crawl the URLs "https://www.example.com" and "https://www.example2.com/" for the crawler with the ID "my-crawler"
+			$ algolia crawler crawl my-crawler --urls https://www.example.com,https://www.example2.com/
 
-			# Crawl the URLs "https://www.netflix.com" and "https://www.primevideo.com/" for the crawler with the ID "my-crawler" and save them in the configuration
-			$ algolia crawler crawl my-crawler --urls https://www.netflix.com,https://www.primevideo.com/ --save
+			# Crawl the URLs "https://www.example.com" and "https://www.example2.com/" for the crawler with the ID "my-crawler" and save them in the configuration
+			$ algolia crawler crawl my-crawler --urls https://www.example.com,https://www.example2.com/ --save
 
-			# Crawl the URLs "https://www.netflix.com" and "https://www.primevideo.com/" for the crawler with the ID "my-crawler" and don't save them in the configuration
-			$ algolia crawler crawl my-crawler --urls https://www.netflix.com,https://www.primevideo.com/ --save=false
+			# Crawl the URLs "https://www.example.com" and "https://www.example2.com/" for the crawler with the ID "my-crawler" and don't save them in the configuration
+			$ algolia crawler crawl my-crawler --urls https://www.example.com,https://www.example2.com/ --save=false
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.ID = args[0]

--- a/pkg/cmd/crawler/crawl/crawl.go
+++ b/pkg/cmd/crawler/crawl/crawl.go
@@ -43,14 +43,14 @@ func NewCrawlCmd(f *cmdutil.Factory, runF func(*CrawlOptions) error) *cobra.Comm
 			The generated records are pushed to the live index if there's no ongoing reindex, and to the temporary index otherwise.
 		`),
 		Example: heredoc.Doc(`
-			# Crawl the URLs "https://www.algolia.com" and "https://www.algolia.com/doc" for the crawler with the ID "my-crawler"
-			$ algolia crawler crawl my-crawler --urls https://www.algolia.com,https://www.algolia.com/doc
+			# Crawl the URLs "https://www.netflix.com" and "https://www.primevideo.com/" for the crawler with the ID "my-crawler"
+			$ algolia crawler crawl my-crawler --urls https://www.netflix.com,https://www.primevideo.com/
 
-			# Crawl the URLs "https://www.algolia.com" and "https://www.algolia.com/doc" for the crawler with the ID "my-crawler" and save them in the configuration
-			$ algolia crawler crawl my-crawler --urls https://www.algolia.com,https://www.algolia.com/doc --save
+			# Crawl the URLs "https://www.netflix.com" and "https://www.primevideo.com/" for the crawler with the ID "my-crawler" and save them in the configuration
+			$ algolia crawler crawl my-crawler --urls https://www.netflix.com,https://www.primevideo.com/ --save
 
-			# Crawl the URLs "https://www.algolia.com" and "https://www.algolia.com/doc" for the crawler with the ID "my-crawler" and don't save them in the configuration
-			$ algolia crawler crawl my-crawler --urls https://www.algolia.com,https://www.algolia.com/doc --save=false
+			# Crawl the URLs "https://www.netflix.com" and "https://www.primevideo.com/" for the crawler with the ID "my-crawler" and don't save them in the configuration
+			$ algolia crawler crawl my-crawler --urls https://www.netflix.com,https://www.primevideo.com/ --save=false
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.ID = args[0]

--- a/pkg/cmd/crawler/test/test.go
+++ b/pkg/cmd/crawler/test/test.go
@@ -48,11 +48,11 @@ func NewTestCmd(f *cmdutil.Factory, runF func(*TestOptions) error) *cobra.Comman
 			You can also override parts of the configuration to try your changes before updating the configuration.
 		`),
 		Example: heredoc.Doc(`
-			# Test the URL "https://www.netflix.com" against the crawler with the ID "my-crawler"
-			$ algolia crawler test my-crawler --url https://www.netflix.com
+			# Test the URL "https://www.example.com" against the crawler with the ID "my-crawler"
+			$ algolia crawler test my-crawler --url https://www.example.com
 
-			# Test the URL "https://www.netflix.com" against the crawler with the ID "my-crawler" and override the configuration with the file "config.json"
-			$ algolia crawler test my-crawler --url https://www.netflix.com -F config.json
+			# Test the URL "https://www.example.com" against the crawler with the ID "my-crawler" and override the configuration with the file "config.json"
+			$ algolia crawler test my-crawler --url https://www.example.com -F config.json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.ID = args[0]

--- a/pkg/cmd/crawler/test/test.go
+++ b/pkg/cmd/crawler/test/test.go
@@ -48,11 +48,11 @@ func NewTestCmd(f *cmdutil.Factory, runF func(*TestOptions) error) *cobra.Comman
 			You can also override parts of the configuration to try your changes before updating the configuration.
 		`),
 		Example: heredoc.Doc(`
-			# Test the URL "https://www.algolia.com" against the crawler with the ID "my-crawler"
-			$ algolia crawler test my-crawler --url https://www.algolia.com
+			# Test the URL "https://www.netflix.com" against the crawler with the ID "my-crawler"
+			$ algolia crawler test my-crawler --url https://www.netflix.com
 
-			# Test the URL "https://www.algolia.com" against the crawler with the ID "my-crawler" and override the configuration with the file "config.json"
-			$ algolia crawler test my-crawler --url https://www.algolia.com -F config.json
+			# Test the URL "https://www.netflix.com" against the crawler with the ID "my-crawler" and override the configuration with the file "config.json"
+			$ algolia crawler test my-crawler --url https://www.netflix.com -F config.json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.ID = args[0]

--- a/pkg/cmd/indices/clear/clear.go
+++ b/pkg/cmd/indices/clear/clear.go
@@ -43,8 +43,8 @@ func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Comm
 			Clear the objects of an index without affecting its settings.
 		`),
 		Example: heredoc.Doc(`
-			# Clear the index named "TEST_PRODUCTS_1"
-			$ algolia index clear TEST_PRODUCTS_1
+			# Clear the index named "MOVIES"
+			$ algolia index clear MOVIES
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Index = args[0]

--- a/pkg/cmd/indices/config/export/export.go
+++ b/pkg/cmd/indices/config/export/export.go
@@ -34,14 +34,14 @@ func NewExportCmd(f *cmdutil.Factory) *cobra.Command {
 			Export an index configuration (settings, synonyms, rules) to a file.
 		`),
 		Example: heredoc.Doc(`
-			# Export the config of the index 'TEST_PRODUCTS' to a .json in the current folder
-			$ algolia index config export TEST_PRODUCTS
+			# Export the config of the index 'MOVIES' to a .json in the current folder
+			$ algolia index config export MOVIES
 
-			# Export the synonyms and rules of the index 'TEST_PRODUCTS' to a .json in the current folder
-			$ algolia index config export TEST_PRODUCTS --scope synonyms,rules
+			# Export the synonyms and rules of the index 'MOVIES' to a .json in the current folder
+			$ algolia index config export MOVIES --scope synonyms,rules
 
-			# Export the config of the index 'TEXT_PRODUCTS' to a .json into 'exports' folder
-			$ algolia index config export TEST_PRODUCTS --directory exports
+			# Export the config of the index 'MOVIES' to a .json into 'exports' folder
+			$ algolia index config export MOVIES --directory exports
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/indices/config/import/import.go
+++ b/pkg/cmd/indices/config/import/import.go
@@ -35,17 +35,17 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 			Import an index configuration (settings, synonyms, rules) from a file.
 		`),
 		Example: heredoc.Doc(`
-			# Import the config from a .json file into 'PROD_TEST_PRODUCTS' index
-			$ algolia index config import PROD_TEST_PRODUCTS -F export-STAGING_TEST_PRODUCTS-APP_ID-1666792448.json
+			# Import the config from a .json file into 'PROD_MOVIES' index
+			$ algolia index config import PROD_MOVIES -F export-STAGING_MOVIES-APP_ID-1666792448.json
 
-			# Import only the synonyms and settings from a .json file to the 'PROD_TEST_PRODUCTS' index
-			$ algolia index config import PROD_TEST_PRODUCTS -F export-STAGING_TEST_PRODUCTS-APP_ID-1666792448.json --scope synonyms, settings
+			# Import only the synonyms and settings from a .json file to the 'PROD_MOVIES' index
+			$ algolia index config import PROD_MOVIES -F export-STAGING_MOVIES-APP_ID-1666792448.json --scope synonyms, settings
 
-			# Import only the synonyms from a .json file to the 'PROD_TEST_PRODUCTS' index and clear all existing ones
-			$ algolia index config import PROD_TEST_PRODUCTS -F export-STAGING_TEST_PRODUCTS-APP_ID-1666792448.json --scope synonyms --clear-existing-synonyms
+			# Import only the synonyms from a .json file to the 'PROD_MOVIES' index and clear all existing ones
+			$ algolia index config import PROD_MOVIES -F export-STAGING_MOVIES-APP_ID-1666792448.json --scope synonyms --clear-existing-synonyms
 
-			# Import only the rules from a .json file to the 'PROD_TEST_PRODUCTS' index and clear all existing ones
-			$ algolia index config import PROD_TEST_PRODUCTS -F export-STAGING_TEST_PRODUCTS-APP_ID-1666792448.json --scope rules --clear-existing-rules
+			# Import only the rules from a .json file to the 'PROD_MOVIES' index and clear all existing ones
+			$ algolia index config import PROD_MOVIES -F export-STAGING_MOVIES-APP_ID-1666792448.json --scope rules --clear-existing-rules
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/indices/copy/copy.go
+++ b/pkg/cmd/indices/copy/copy.go
@@ -51,14 +51,14 @@ func NewCopyCmd(f *cmdutil.Factory, runF func(*CopyOptions) error) *cobra.Comman
 			Make a copy of an index, including its records, settings, synonyms, and rules except for the "enableReRanking" setting.
 		`),
 		Example: heredoc.Doc(`
-			# Copy the records, settings, synonyms and rules from the "TEST_PRODUCTS_1" index to the "TEST_PRODUCTS_2" index
-			$ algolia indices copy TEST_PRODUCTS DEV_PRODUCTS
+			# Copy the records, settings, synonyms and rules from the "SERIES" index to the "MOVIES" index
+			$ algolia indices copy SERIES MOVIES
 
-			# Copy only the synonyms of the "TEST_PRODUCTS_1" to the "TEST_PRODUCTS_2" index
-			$ algolia indices copy TEST_PRODUCTS DEV_PRODUCTS --scope synonyms
+			# Copy only the synonyms of the "SERIES" to the "MOVIES" index
+			$ algolia indices copy SERIES MOVIES --scope synonyms
 
-			# Copy the synonyms and rules of the index "TEST_PRODUCTS_1" to the "TEST_PRODUCTS_2" index
-			$ algolia indices copy TEST_PRODUCTS DEV_PRODUCTS --scope synonyms,rules
+			# Copy the synonyms and rules of the index "SERIES" to the "MOVIES" index
+			$ algolia indices copy SERIES MOVIES --scope synonyms,rules
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.SourceIndex = args[0]

--- a/pkg/cmd/indices/delete/delete.go
+++ b/pkg/cmd/indices/delete/delete.go
@@ -46,17 +46,17 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			This command permanently removes one or multiple indices from your application, and removes their metadata and configured settings.
 		`),
 		Example: heredoc.Doc(`
-			# Delete the index named "TEST_PRODUCTS_1"
-			$ algolia indices delete TEST_PRODUCTS_1
+			# Delete the index named "MOVIES"
+			$ algolia indices delete MOVIES
 
-      # Delete the index named "TEST_PRODUCTS_1" and its replicas
-      $ algolia indices delete TEST_PRODUCTS_1 --includeReplicas
+      # Delete the index named "MOVIES" and its replicas
+      $ algolia indices delete MOVIES --includeReplicas
 
-			# Delete the index named "TEST_PRODUCTS_1", skipping the confirmation prompt
-			$ algolia indices delete TEST_PRODUCTS_1 -y
+			# Delete the index named "MOVIES", skipping the confirmation prompt
+			$ algolia indices delete MOVIES -y
 
 			# Delete multiple indices
-			$ algolia indices delete TEST_PRODUCTS_1 TEST_PRODUCTS_2 TEST_PRODUCTS_3
+			$ algolia indices delete MOVIES SERIES ANIMES
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indices = args

--- a/pkg/cmd/indices/move/move.go
+++ b/pkg/cmd/indices/move/move.go
@@ -48,8 +48,8 @@ func NewMoveCmd(f *cmdutil.Factory, runF func(*MoveOptions) error) *cobra.Comman
 			Move the full content (objects, synonyms, rules, settings) of the given source index into the destination one, effectively deleting the source index.
 		`),
 		Example: heredoc.Doc(`
-			# Move the "TEST_PRODUCTS" index to "DEV_PRODUCTS"
-			$ algolia indices move TEST_PRODUCTS DEV_PRODUCTS
+			# Move the "TEST_MOVIES" index to "DEV_MOVIES"
+			$ algolia indices move TEST_MOVIES DEV_MOVIES
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.SourceIndex = args[0]

--- a/pkg/cmd/objects/browse/browse.go
+++ b/pkg/cmd/objects/browse/browse.go
@@ -39,22 +39,25 @@ func NewBrowseCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:               "browse <index>",
 		Args:              validators.ExactArgs(1),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
-		Short:             "Browse the index objects",
+		Annotations: map[string]string{
+			"runInWebCLI": "true",
+		},
+		Short: "Browse the index objects",
 		Long: heredoc.Doc(`
 			This command browse the objects of the specified index.
 		`),
 		Example: heredoc.Doc(`
-			# Browse the objects from the "BOOKS" index
-			$ algolia objects browse BOOKS
+			# Browse the objects from the "MOVIES" index
+			$ algolia objects browse MOVIES
 
-			# Browse the objects from the "BOOKS" index and select which attributes to retrieve
-			$ algolia objects browse BOOKS --attributesToRetrieve author,title,description
+			# Browse the objects from the "MOVIES" index and select which attributes to retrieve
+			$ algolia objects browse MOVIES --attributesToRetrieve title,overview
 
-			# Browse the objects from the "BOOKS" index with filters
-			$ algolia objects browse BOOKS --filters "'(category:Book OR category:Ebook) AND _tags:published'"
+			# Browse the objects from the "MOVIES" index with filters
+			$ algolia objects browse MOVIES --filters "genres:Drama"
 
-			# Browse the objects from the "BOOKS" and export the results to a new line delimited JSON (ndjson) file
-			$ algolia objects browse BOOKS > books.ndjson
+			# Browse the objects from the "MOVIES" and export the results to a new line delimited JSON (ndjson) file
+			$ algolia objects browse MOVIES > movies.ndjson
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/objects/delete/delete.go
+++ b/pkg/cmd/objects/delete/delete.go
@@ -53,14 +53,14 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			You can either directly specify the objects to delete by theirs IDs and/or use the filters related flags to delete the matching objects.
 		`),
 		Example: heredoc.Doc(`
-			# Delete one single object with the ID "1" from the "TEST_PRODUCTS_1" index
-			$ algolia objects delete TEST_PRODUCTS_1 --object-ids 1
+			# Delete one single object with the ID "1" from the "MOVIES" index
+			$ algolia objects delete MOVIES --object-ids 1
 
-			# Delete multiple objects with the IDs "1" and "2" from the "TEST_PRODUCTS_1" index
-			$ algolia objects delete TEST_PRODUCTS_1 --object-ids 1,2
+			# Delete multiple objects with the IDs "1" and "2" from the "MOVIES" index
+			$ algolia objects delete MOVIES --object-ids 1,2
 
-			# Delete all objects matching the filters "brand:Apple" from the "TEST_PRODUCTS_1" index
-			$ algolia objects delete TEST_PRODUCTS_1 --filters "brand:Apple" --confirm
+			# Delete all objects matching the filters "type:Scripted" from the "MOVIES" index
+			$ algolia objects delete MOVIES --filters "type:Scripted" --confirm
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/objects/import/import.go
+++ b/pkg/cmd/objects/import/import.go
@@ -48,14 +48,14 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 			The file must contains one single JSON object per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
-			# Import objects from the "data.ndjson" file to the "TEST_PRODUCTS_1" index
-			$ algolia objects import TEST_PRODUCTS_1 -F data.ndjson
+			# Import objects from the "data.ndjson" file to the "MOVIES" index
+			$ algolia objects import MOVIES -F data.ndjson
 
-			# Import objects from the standard input to the "TEST_PRODUCTS_1" index
-			$ cat data.ndjson | algolia objects import TEST_PRODUCTS_1 -F -
+			# Import objects from the standard input to the "MOVIES" index
+			$ cat data.ndjson | algolia objects import MOVIES -F -
 
-			# Browse the objects in the "TEST_PRODUCTS_1" index and import them to the "TEST_PRODUCTS_2" index
-			$ algolia objects browse TEST_PRODUCTS_1 | algolia objects import TEST_PRODUCTS_2 -F -
+			# Browse the objects in the "SERIES" index and import them to the "MOVIES" index
+			$ algolia objects browse SERIES | algolia objects import MOVIES -F -
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Index = args[0]

--- a/pkg/cmd/objects/update/update.go
+++ b/pkg/cmd/objects/update/update.go
@@ -56,17 +56,17 @@ func NewUpdateCmd(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Co
 			The file must contains one single JSON object per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
-			# Update objects from the "objects.ndjson" file to the "TEST_PRODUCTS" index
-			$ algolia objects update TEST_PRODUCTS -F objects.ndjson
+			# Update objects from the "objects.ndjson" file to the "MOVIES" index
+			$ algolia objects update MOVIES -F objects.ndjson
 
-			# Update objects from the "objects.ndjson" file to the "TEST_PRODUCTS" index and create the objects if they don't exist
-			$ algolia objects update TEST_PRODUCTS -F objects.ndjson --create-if-not-exists
+			# Update objects from the "objects.ndjson" file to the "MOVIES" index and create the objects if they don't exist
+			$ algolia objects update MOVIES -F objects.ndjson --create-if-not-exists
 
-			# Update objects from the "objects.ndjson" file to the "TEST_PRODUCTS" index and wait for the operation to complete
-			$ algolia objects update TEST_PRODUCTS -F objects.ndjson --wait
+			# Update objects from the "objects.ndjson" file to the "MOVIES" index and wait for the operation to complete
+			$ algolia objects update MOVIES -F objects.ndjson --wait
 
-			# Update objects from the "objects.ndjson" file to the "TEST_PRODUCTS" index and continue updating objects even if some objects are invalid
-			$ algolia objects update TEST_PRODUCTS -F objects.ndjson --continue-on-errors
+			# Update objects from the "objects.ndjson" file to the "MOVIES" index and continue updating objects even if some objects are invalid
+			$ algolia objects update MOVIES -F objects.ndjson --continue-on-errors
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Index = args[0]

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -60,10 +60,10 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-			$ algolia search MY_INDEX --query "foo"
-			$ algolia objects browse MY_INDEX
+			$ algolia search MOVIES --query "toy story"
+			$ algolia objects browse MOVIES
 			$ algolia apikeys create --acl search
-			$ algolia rules import MY_INDEX -f rules.json
+			$ algolia rules import MOVIES -f rules.json
 		`),
 	}
 

--- a/pkg/cmd/rules/browse/browse.go
+++ b/pkg/cmd/rules/browse/browse.go
@@ -39,12 +39,15 @@ func NewBrowseCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:              validators.ExactArgs(1),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
 		Short:             "List all the rules of an index",
+		Annotations: map[string]string{
+			"runInWebCLI": "true",
+		},
 		Example: heredoc.Doc(`
-			# List all the rules of the "TEST_PRODUCTS_1" index
-			$ algolia rules browse TEST_PRODUCTS_1
+			# List all the rules of the "MOVIES" index
+			$ algolia rules browse MOVIES
 
-			# List all the rules of the "TEST_PRODUCTS_1" index and save them to a 'rules.ndjson' file
-			$ algolia rules browse TEST_PRODUCTS_1 --json > rules.ndjson
+			# List all the rules of the "MOVIES" index and save them to a 'rules.ndjson' file
+			$ algolia rules browse MOVIES --json > rules.ndjson
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/rules/delete/delete.go
+++ b/pkg/cmd/rules/delete/delete.go
@@ -49,11 +49,11 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			This command deletes the rules from the specified index.
 		`),
 		Example: heredoc.Doc(`
-			# Delete one single rule with the ID "1" from the "TEST_PRODUCTS_1" index
-			$ algolia rules delete TEST_PRODUCTS_1 --rule-ids 1
+			# Delete one single rule with the ID "1" from the "MOVIES" index
+			$ algolia rules delete MOVIES --rule-ids 1
 
-			# Delete multiple rules with the IDs "1" and "2" from the "TEST_PRODUCTS_1" index
-			$ algolia rules delete TEST_PRODUCTS_1 --rule-ids 1,2
+			# Delete multiple rules with the IDs "1" and "2" from the "MOVIES" index
+			$ algolia rules delete MOVIES --rule-ids 1,2
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/rules/import/import.go
+++ b/pkg/cmd/rules/import/import.go
@@ -52,17 +52,17 @@ func NewImportCmd(f *cmdutil.Factory, runF func(*ImportOptions) error) *cobra.Co
 			The file must contains one JSON rule per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
-			# Import rules from the "rules.ndjson" file to the "TEST_PRODUCTS_1" index
-			$ algolia rules import TEST_PRODUCTS_1 -F rules.ndjson
+			# Import rules from the "rules.ndjson" file to the "MOVIES" index
+			$ algolia rules import MOVIES -F rules.ndjson
 
-			# Import rules from the standard input to the "TEST_PRODUCTS_1" index
-			$ cat rules.ndjson | algolia rules import TEST_PRODUCTS_1 -F -
+			# Import rules from the standard input to the "MOVIES" index
+			$ cat rules.ndjson | algolia rules import MOVIES -F -
 
-			# Browse the rules in the "TEST_PRODUCTS_1" index and import them to the "TEST_PRODUCTS_2" index
-			$ algolia rules browse TEST_PRODUCTS_2 | algolia rules import TEST_PRODUCTS_2 -F -
+			# Browse the rules in the "SERIES" index and import them to the "MOVIES" index
+			$ algolia rules browse SERIES | algolia rules import MOVIES -F -
 
-			# Import rules from the "rules.ndjson" file to the "TEST_PRODUCTS_1" index and don't forward them to the index replicas
-			$ algolia import TEST_PRODUCTS_1 -F rules.ndjson -f=false
+			# Import rules from the "rules.ndjson" file to the "MOVIES" index and don't forward them to the index replicas
+			$ algolia import MOVIES -F rules.ndjson -f=false
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/search/search.go
+++ b/pkg/cmd/search/search.go
@@ -45,20 +45,20 @@ func NewSearchCmd(f *cmdutil.Factory) *cobra.Command {
 			"runInWebCLI": "true",
 		},
 		Example: heredoc.Doc(`
-			# Search for objects in the "BOOKS" index matching the query "tolkien"
-			$ algolia search BOOKS --query "tolkien"
+			# Search for objects in the "MOVIES" index matching the query "toy story"
+			$ algolia search MOVIES --query "toy story"
 
-			# Search for objects in the "BOOKS" index matching the query "tolkien" with filters
-			$ algolia search BOOKS --query "tolkien" --filters "'(category:Book OR category:Ebook) AND _tags:published'"
+			# Search for objects in the "MOVIES" index matching the query "toy story" with filters
+			$ algolia search MOVIES --query "toy story" --filters "'(genres:Animation OR genres:Family) AND original_language:en'"
 
-			# Search for objects in the "BOOKS" index matching the query "tolkien" while setting the number of hits per page and specifying the page to retrieve
-			$ algolia search BOOKS --query "tolkien" --hitsPerPage 2 --page 4
+			# Search for objects in the "MOVIES" index matching the query "toy story" while setting the number of hits per page and specifying the page to retrieve
+			$ algolia search MOVIES --query "toy story" --hitsPerPage 2 --page 4
 
-			# Search for objects in the "BOOKS" index matching the query "tolkien" and export the response to a .json file
-			$ algolia search BOOKS --query "tolkien" > books.json
+			# Search for objects in the "MOVIES" index matching the query "toy story" and export the response to a .json file
+			$ algolia search MOVIES --query "toy story" > movies.json
 
-			# Search for objects in the "BOOKS" index matching the query "tolkien" and only export the results to a .json file
-			$ algolia search BOOKS --query "tolkien" --output="jsonpath={$.Hits}" > books.json
+			# Search for objects in the "MOVIES" index matching the query "toy story" and only export the results to a .json file
+			$ algolia search MOVIES --query "toy story" --output="jsonpath={$.Hits}" > movies.json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/settings/get/list.go
+++ b/pkg/cmd/settings/get/list.go
@@ -36,9 +36,12 @@ func NewGetCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "get <index>",
 		Args:  validators.ExactArgs(1),
 		Short: "Get the settings of the specified index.",
+		Annotations: map[string]string{
+			"runInWebCLI": "true",
+		},
 		Example: heredoc.Doc(`
 			# Store the settings of an index in a file
-			$ algolia settings get PRODUCTS > products_settings.json
+			$ algolia settings get MOVIES > movies_settings.json
 		`),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/settings/import/import.go
+++ b/pkg/cmd/settings/import/import.go
@@ -40,8 +40,8 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
 		Short:             "Import the index settings from the given file",
 		Example: heredoc.Doc(`
-			# Import the settings from "settings.json" to the "TEST_PRODUCTS_1" index
-			$ algolia settings import TEST_PRODUCTS_1 -F settings.json
+			# Import the settings from "settings.json" to the "MOVIES" index
+			$ algolia settings import MOVIES -F settings.json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Index = args[0]

--- a/pkg/cmd/settings/set/set.go
+++ b/pkg/cmd/settings/set/set.go
@@ -39,8 +39,8 @@ func NewSetCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:  validators.ExactArgs(1),
 		Short: "Set the settings of the specified index.",
 		Example: heredoc.Doc(`
-			# Set the typo tolerance to false on the PRODUCTS index
-			$ algolia settings set PRODUCTS --typoTolerance="false"
+			# Set the typo tolerance to false on the MOVIES index
+			$ algolia settings set MOVIES --typoTolerance="false"
 		`),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/synonyms/browse/browse.go
+++ b/pkg/cmd/synonyms/browse/browse.go
@@ -38,12 +38,15 @@ func NewBrowseCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:              validators.ExactArgs(1),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
 		Short:             "List all the the synonyms of the given index",
+		Annotations: map[string]string{
+			"runInWebCLI": "true",
+		},
 		Example: heredoc.Doc(`
-			# List all the synonyms of the 'TEST_PRODUCTS_1' index
-			$ algolia synonyms browse TEST_PRODUCTS_1
+			# List all the synonyms of the 'MOVIES' index
+			$ algolia synonyms browse MOVIES
 
-			# List all the synonyms of the 'TEST_PRODUCTS_1' and save them to the 'synonyms.json' file
-			$ algolia synonyms browse TEST_PRODUCTS_1 > synonyms.json
+			# List all the synonyms of the 'MOVIES' and save them to the 'synonyms.json' file
+			$ algolia synonyms browse MOVIES > synonyms.json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/synonyms/delete/delete.go
+++ b/pkg/cmd/synonyms/delete/delete.go
@@ -49,11 +49,11 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			This command deletes the synonyms from the specified index.
 		`),
 		Example: heredoc.Doc(`
-			# Delete one single synonym with the ID "1" from the "TEST_PRODUCTS_1" index
-			$ algolia synonyms delete TEST_PRODUCTS_1 --synonym-ids 1
+			# Delete one single synonym with the ID "1" from the "MOVIES" index
+			$ algolia synonyms delete MOVIES --synonym-ids 1
 
-			# Delete multiple synonyms with the IDs "1" and "2" from the "TEST_PRODUCTS_1" index
-			$ algolia synonyms delete TEST_PRODUCTS_1 --synonym-ids 1,2
+			# Delete multiple synonyms with the IDs "1" and "2" from the "MOVIES" index
+			$ algolia synonyms delete MOVIES --synonym-ids 1,2
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/synonyms/import/import.go
+++ b/pkg/cmd/synonyms/import/import.go
@@ -48,20 +48,20 @@ func NewImportCmd(f *cmdutil.Factory, runF func(*ImportOptions) error) *cobra.Co
 			The file must contains one single JSON synonym per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
-			# Import synonyms from the "synonyms.ndjson" file to the "TEST_PRODUCTS_1" index
-			$ algolia synonyms import TEST_PRODUCTS_1 -F synonyms.ndjson
+			# Import synonyms from the "synonyms.ndjson" file to the "MOVIES" index
+			$ algolia synonyms import MOVIES -F synonyms.ndjson
 
-			# Import synonyms from the standard input to the "TEST_PRODUCTS_1" index
-			$ cat synonyms.ndjson | algolia synonyms import TEST_PRODUCTS_1 -F -
+			# Import synonyms from the standard input to the "MOVIES" index
+			$ cat synonyms.ndjson | algolia synonyms import MOVIES -F -
 
-			# Browse the synonyms in the "TEST_PRODUCTS_1" index and import them to the "TEST_PRODUCTS_2" index
-			$ algolia synonyms browse TEST_PRODUCTS_1 | algolia synonyms import TEST_PRODUCTS_2 -F -
+			# Browse the synonyms in the "SERIES" index and import them to the "MOVIES" index
+			$ algolia synonyms browse SERIES | algolia synonyms import MOVIES -F -
 
-			# Import synonyms from the "synonyms.ndjson" file to the "TEST_PRODUCTS_1" index and replace existing synonyms
-			$ algolia synonyms import TEST_PRODUCTS_1 -F synonyms.ndjson -r
+			# Import synonyms from the "synonyms.ndjson" file to the "MOVIES" index and replace existing synonyms
+			$ algolia synonyms import MOVIES -F synonyms.ndjson -r
 
-			# Import synonyms from the "synonyms.ndjson" file to the "TEST_PRODUCTS_1" index and don't forward the synonyms to the index replicas
-			$ algolia synonyms import TEST_PRODUCTS_1 -F synonyms.ndjson -f=false
+			# Import synonyms from the "synonyms.ndjson" file to the "MOVIES" index and don't forward the synonyms to the index replicas
+			$ algolia synonyms import MOVIES -F synonyms.ndjson -f=false
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Index = args[0]

--- a/pkg/cmd/synonyms/save/save.go
+++ b/pkg/cmd/synonyms/save/save.go
@@ -49,8 +49,8 @@ func NewSaveCmd(f *cmdutil.Factory, runF func(*SaveOptions) error) *cobra.Comman
 			If the synonym doesn't exist yet, a new one is created.
 		`),
 		Example: heredoc.Doc(`
-			# Save one standard synonym with ID "1" and "foo" and "bar" synonyms to the "TEST_PRODUCTS_1" index
-			$ algolia synonyms save TEST_PRODUCTS_1 --id 1 --synonyms foo,bar
+			# Save one standard synonym with ID "1" and "foo" and "bar" synonyms to the "MOVIES" index
+			$ algolia synonyms save MOVIES --id 1 --synonyms foo,bar
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]


### PR DESCRIPTION
## PR for the changes implied by this one: https://github.com/algolia/new-world-docs/pull/353

## Changes

- update all the examples in the CLI to match `new-world-docs` indexes and context
- enable `runInWebCLI` option for the commands and examples runnable by the web CLI in the `new-world-docs`
- fix `.mdx` template