### PR TITLE
profile/list: show errors in table listing instead of failing

### DIFF
--- a/pkg/cmd/profile/list/list.go
+++ b/pkg/cmd/profile/list/list.go
@@ -71,7 +71,7 @@ func runListCmd(opts *AddOptions) error {
 		client := search.NewClient(profile.ApplicationID, profile.AdminAPIKey)
 		res, err := client.ListIndices()
 		if err != nil {
-			return err
+			return fmt.Errorf("could not retrieve indices for profile %q (AppID %q): %w", profile.Name, profile.ApplicationID, err)
 		}
 
 		table.AddField(profile.Name, nil, nil)

--- a/pkg/cmd/profile/list/list.go
+++ b/pkg/cmd/profile/list/list.go
@@ -68,15 +68,17 @@ func runListCmd(opts *AddOptions) error {
 
 	opts.IO.StartProgressIndicatorWithLabel("Fetching configured profiles")
 	for _, profile := range profiles {
+		table.AddField(profile.Name, nil, nil)
+		table.AddField(profile.ApplicationID, nil, nil)
+
 		client := search.NewClient(profile.ApplicationID, profile.APIKey)
 		res, err := client.ListIndices()
 		if err != nil {
-			return fmt.Errorf("could not retrieve indices for profile %q (AppID %q): %w", profile.Name, profile.ApplicationID, err)
+			table.AddField(err.Error(), nil, nil)
+		} else {
+			table.AddField(fmt.Sprintf("%d", len(res.Items)), nil, nil)
 		}
 
-		table.AddField(profile.Name, nil, nil)
-		table.AddField(profile.ApplicationID, nil, nil)
-		table.AddField(fmt.Sprintf("%d", len(res.Items)), nil, nil)
 		if profile.Default {
 			table.AddField(cs.SuccessIcon(), nil, nil)
 		} else {


### PR DESCRIPTION
Without annotation the error is not helpful when you have multiple profiles.

Note: this also uses the AdminAPIKey, which might need another change to amend.