### PR TITLE
fix(cmd): profile list using APIKey instead of adminAPIKey

### DIFF
--- a/pkg/cmd/profile/list/list.go
+++ b/pkg/cmd/profile/list/list.go
@@ -68,7 +68,7 @@ func runListCmd(opts *AddOptions) error {
 
 	opts.IO.StartProgressIndicatorWithLabel("Fetching configured profiles")
 	for _, profile := range profiles {
-		client := search.NewClient(profile.ApplicationID, profile.AdminAPIKey)
+		client := search.NewClient(profile.ApplicationID, profile.APIKey)
 		res, err := client.ListIndices()
 		if err != nil {
 			return err


### PR DESCRIPTION
fix #146 