### PR TITLE
fix(crawler): Correctly display error messages

### DIFF
--- a/api/crawler/client.go
+++ b/api/crawler/client.go
@@ -65,10 +65,15 @@ func (c *Client) request(res interface{}, method string, path string, body inter
 			for _, e := range errResp.Err.Errors {
 				errs = append(errs, e.Message)
 			}
-			return fmt.Errorf("%s: %s", errResp.Err.Message, errs)
+			return fmt.Errorf("[%s] %s", errResp.Err.Code, errs)
 		}
 
-		return errors.New(errResp.Err.Message)
+		// Message might be empty
+		if errResp.Err.Message == "" {
+			return errors.New(errResp.Err.Code)
+		} else {
+			return fmt.Errorf("[%s] %s", errResp.Err.Code, errResp.Err.Message)
+		}
 	}
 
 	if res != nil {

--- a/pkg/cmd/crawler/crawl/crawl.go
+++ b/pkg/cmd/crawler/crawl/crawl.go
@@ -90,7 +90,7 @@ func runCrawlCmd(opts *CrawlOptions) error {
 	_, err = client.CrawlURLs(opts.ID, opts.URLs, opts.Save, opts.SaveSpecified)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
-		return err
+		return fmt.Errorf("%s Crawler API error: %w", cs.FailureIcon(), err)
 	}
 
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -48,6 +48,13 @@ func ErrorResponse() Responder {
 	}
 }
 
+func ErrorResponseWithBody(body interface{}) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		b, _ := json.Marshal(body)
+		return httpResponse(400, req, bytes.NewBuffer(b)), nil
+	}
+}
+
 func httpResponse(status int, req *http.Request, body io.Reader) *http.Response {
 	return &http.Response{
 		StatusCode: status,


### PR DESCRIPTION
The Crawler API does not always provide an error `Message`. IN this case, we show return the error `Code` instead.