### PR TITLE
fix(rules): missing word in example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 	git -C $(DOCS_FOLDER) checkout -B feat/cli-'$(GITHUB_REF:refs/tags/v%=%)'
 	git -C $(DOCS_FOLDER) commit -m 'feat: update cli commands data for $(GITHUB_REF:refs/tags/v%=%) version' || true
 	git -C $(DOCS_FOLDER) push --set-upstream origin feat/cli-'$(GITHUB_REF:refs/tags/v%=%)'
-	cd $(DOCS_FOLDER); gh pr create -f -b "Changelog: https://github.com/algolia/cli/releases/tag/$(GITHUB_REF:refs/tags/v%=%)"
+	cd $(DOCS_FOLDER); gh pr create -f -b "Changelog: https://github.com/algolia/cli/releases/tag/$(GITHUB_REF:refs/tags/%=%)"
 
 ## Create a new PR (or update the existing one) to update the API specs
 api-specs-pr:

--- a/pkg/cmd/rules/import/import.go
+++ b/pkg/cmd/rules/import/import.go
@@ -65,7 +65,7 @@ func NewImportCmd(f *cmdutil.Factory, runF func(*ImportOptions) error) *cobra.Co
 			$ algolia rules browse SERIES | algolia rules import MOVIES -F -
 
 			# Import rules from the "rules.ndjson" file to the "MOVIES" index and don't forward them to the index replicas
-			$ algolia import MOVIES -F rules.ndjson -f=false
+			$ algolia rules import MOVIES -F rules.ndjson -f=false
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]


### PR DESCRIPTION
There was a `rules` missing in the examples for the `algolia rules import` command.