### PR TITLE
fix: apply options correctly for indices config import

### DIFF
--- a/pkg/cmd/indices/config/import/import.go
+++ b/pkg/cmd/indices/config/import/import.go
@@ -124,7 +124,7 @@ func runImportCmd(opts *config.ImportOptions) error {
 			return err
 		}
 		_, err = indice.SaveSynonyms(
-      synonyms,
+			synonyms,
 			opt.ForwardToReplicas(opts.ForwardSynonymsToReplicas),
 			opt.ReplaceExistingSynonyms(opts.ClearExistingSynonyms),
 		)
@@ -134,7 +134,7 @@ func runImportCmd(opts *config.ImportOptions) error {
 	}
 	if len(opts.ImportConfig.Rules) > 0 && utils.Contains(opts.Scope, "rules") {
 		_, err = indice.SaveRules(
-      opts.ImportConfig.Rules,
+			opts.ImportConfig.Rules,
 			opt.ForwardToReplicas(opts.ForwardRulesToReplicas),
 			opt.ClearExistingRules(opts.ClearExistingRules),
 		)

--- a/pkg/cmd/indices/config/import/import.go
+++ b/pkg/cmd/indices/config/import/import.go
@@ -123,22 +123,21 @@ func runImportCmd(opts *config.ImportOptions) error {
 		if err != nil {
 			return err
 		}
-		_, err = indice.SaveSynonyms(synonyms,
-			[]interface{}{
-				opt.ForwardToReplicas(opts.ForwardSynonymsToReplicas),
-				opt.ReplaceExistingSynonyms(opts.ClearExistingSynonyms),
-			},
+		_, err = indice.SaveSynonyms(
+      synonyms,
+			opt.ForwardToReplicas(opts.ForwardSynonymsToReplicas),
+			opt.ReplaceExistingSynonyms(opts.ClearExistingSynonyms),
 		)
 		if err != nil {
 			return fmt.Errorf("%s An error occurred when saving synonyms: %w", cs.FailureIcon(), err)
 		}
 	}
 	if len(opts.ImportConfig.Rules) > 0 && utils.Contains(opts.Scope, "rules") {
-		_, err = indice.SaveRules(opts.ImportConfig.Rules,
-			[]interface{}{
-				opt.ForwardToReplicas(opts.ForwardRulesToReplicas),
-				opt.ClearExistingRules(opts.ClearExistingRules),
-			})
+		_, err = indice.SaveRules(
+      opts.ImportConfig.Rules,
+			opt.ForwardToReplicas(opts.ForwardRulesToReplicas),
+			opt.ClearExistingRules(opts.ClearExistingRules),
+		)
 		if err != nil {
 			return fmt.Errorf("%s An error occurred when saving rules: %w", cs.FailureIcon(), err)
 		}


### PR DESCRIPTION
In the `algolia indices config import` command, these options were not passed correctly to the API client methods 'SaveSynonyms' and 'SaveRules'.

- `--clear-existing-rules`
- `--clear-existing-synonyms` 
- `--forward-synonyms-to-replicas`

Fixes #174 