### PR TITLE
chore: publish CLI docs to docs-new as MDX

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Docs checkout
         uses: actions/checkout@v4
         with:
-          repository: algolia/doc
+          repository: algolia/docs-new
           path: docs
           fetch-depth: 0
           token: ${{secrets.GORELEASER_GITHUB_TOKEN}}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,15 @@
 # AGENTS.md
+
 Guidance for coding agents working in `github.com/algolia/cli`.
 
 ## Scope
+
 - Applies to the whole repository.
 - Prefer small, local changes over broad refactors.
 - Follow existing Go + Cobra CLI patterns.
 
 ## Repository Facts
+
 - Language: Go.
 - Module: `github.com/algolia/cli`.
 - Go version: `1.23.0`; toolchain: `go1.23.4`.
@@ -15,17 +18,20 @@ Guidance for coding agents working in `github.com/algolia/cli`.
 - Command tree: `pkg/cmd/...`.
 
 ## Cursor / Copilot Rules
+
 - No `.cursor/rules/` directory was found.
 - No `.cursorrules` file was found.
 - No `.github/copilot-instructions.md` file was found.
 - Use this file plus the existing codebase as the repo-specific source of truth.
 
 ## Tooling
+
 - Preferred toolchain is listed in `devbox.json`.
 - Common tools expected here: `go`, `task`, `golangci-lint`, `gofumpt`, `golines`, `gh`, `curl`.
 - E2E tests require `ALGOLIA_APPLICATION_ID` and `ALGOLIA_API_KEY` in the environment or root `.env`.
 
 ## Build Commands
+
 Preferred:
 
 ```sh
@@ -42,6 +48,7 @@ go build -v ./...
 - CI also checks `go build -v ./...`.
 
 ## Test Commands
+
 All unit tests:
 
 ```sh
@@ -92,12 +99,13 @@ golines -w pkg cmd test internal api e2e
 ```sh
 go generate ./...
 go run ./cmd/docs --app_data-path tmp
-go run ./cmd/docs --app_data-path tmp --target new
+go run ./cmd/docs --app_data-path tmp
 ```
 
 Run generation when changing generated flags or API-spec-derived code.
 
 ## Fast Local Verification
+
 For substantial changes, prefer this order:
 
 ```sh
@@ -110,6 +118,7 @@ task build
 Use narrower verification for small edits.
 
 ## Architecture Guidelines
+
 - Add CLI commands under `pkg/cmd/<domain>`.
 - Construct commands with `New...Cmd` functions.
 - Keep option structs close to their commands.
@@ -118,22 +127,27 @@ Use narrower verification for small edits.
 - Keep docs-generation logic in `internal/docs` and `cmd/docs`.
 
 ## Code Style
+
 ### Imports
+
 - Use standard Go grouping: stdlib, third-party, local module.
 - Let `gofumpt` handle ordering and spacing.
 - Avoid aliases unless they prevent collisions or materially improve clarity.
 
 ### Formatting
+
 - Run `gofumpt` on all modified Go files.
 - Run `golines` if wrapping becomes awkward.
 - Preserve existing multiline layout for structs, literals, and signatures.
 
 ### Types And Structs
+
 - Prefer explicit structs for command options and helper state.
 - Keep exported APIs minimal.
 - Use `any` only where JSON-like dynamic values are genuinely needed.
 
 ### Naming
+
 - Exported names: PascalCase.
 - Unexported names: camelCase.
 - Command constructors: `NewXCmd`.
@@ -141,6 +155,7 @@ Use narrower verification for small edits.
 - Match surrounding test naming, commonly `Test_runXCmd`, `TestNewXCmd`, or `Test_Feature`.
 
 ### Cobra Conventions
+
 - Use `RunE`, not `Run`, for command handlers.
 - Validate args with `cobra.ExactArgs`, `cobra.MinimumNArgs`, or repo validators.
 - Use `ValidArgsFunction` when completion helpers already exist.
@@ -148,6 +163,7 @@ Use narrower verification for small edits.
 - Use heredocs for multiline examples and help text.
 
 ### Error Handling
+
 - Return errors instead of exiting except in true entrypoints like `main()`.
 - Wrap with `%w` when the original cause matters.
 - Use plain `return err` when extra context adds no value.
@@ -156,17 +172,20 @@ Use narrower verification for small edits.
 - Stop progress indicators on all error paths after starting them.
 
 ### I/O And UX
+
 - Use factory-provided `IOStreams` for stdout, stderr, TTY checks, colors, and progress indicators.
 - Keep non-TTY output deterministic and script-friendly.
 - Use structured output helpers for commands that support `--output`.
 - Preserve dry-run behavior: validate, summarize, and avoid side effects.
 
 ### Config And Clients
+
 - Read config through `config.IConfig`.
 - Acquire API clients from injected functions like `SearchClient` and `CrawlerClient`.
 - Do not hardcode credentials, hosts, or profile logic.
 
 ### Testing Style
+
 - Prefer table-driven tests for flags, output modes, and edge cases.
 - Use `test.NewFactory(...)` and `test.Execute(...)` for command tests.
 - Stub API calls with `pkg/httpmock`.
@@ -175,6 +194,7 @@ Use narrower verification for small edits.
 - For E2E, add new `txtar` cases under `e2e/testscripts/<area>` and register them in `e2e/e2e_test.go`.
 
 ## Change Guidance
+
 - Check for an existing helper before adding a new utility.
 - If flag surfaces or generated spec flags change, run `go generate ./...`.
 - If command help or command trees change, consider whether docs generation should be rerun.

--- a/Makefile
+++ b/Makefile
@@ -9,32 +9,23 @@ test:
 	go test ./... -p 1
 .PHONY: test
 
-## Build & publish the old documentation
-VARIATION ?= old
-ifeq ($(VARIATION),old)
-DOCS_FOLDER = docs
-DOCS_GENERATED_PATH = app_data/cli/commands
-DOCS_REPO_URL = git@github.com:algolia/doc.git
-DOCS_BRANCH = master
-DOCS_EXTENSION = yml
-else ifeq ($(VARIATION),new)
-DOCS_FOLDER = new-world-docs
-DOCS_GENERATED_PATH = apps/docs/content/pages/tools/cli/commands
-DOCS_REPO_URL = https://github.com/algolia/new-world-docs.git
+## Build & publish the CLI documentation
+DOCS_FOLDER ?= docs
+DOCS_GENERATED_PATH = doc/tools/cli/commands
+DOCS_REPO_URL = https://github.com/algolia/docs-new.git
 DOCS_BRANCH = main
-DOCS_EXTENSION = mdx
-endif
 
 docs:
 	git clone $(DOCS_REPO_URL) "$@"
 
 .PHONY: docs-commands-data
 docs-commands-data: docs
-	git -C $(DOCS_FOLDER) pull
 	git -C $(DOCS_FOLDER) checkout $(DOCS_BRANCH)
-	git -C $(DOCS_FOLDER) rm '$(DOCS_GENERATED_PATH)/*.$(DOCS_EXTENSION)' 2>/dev/null || true
-	go run ./cmd/docs --app_data-path $(DOCS_FOLDER)/$(DOCS_GENERATED_PATH) --target $(VARIATION)
-	git -C $(DOCS_FOLDER) add '$(DOCS_GENERATED_PATH)/*.$(DOCS_EXTENSION)'
+	git -C $(DOCS_FOLDER) pull --ff-only origin $(DOCS_BRANCH)
+	rm -rf "$(DOCS_FOLDER)/$(DOCS_GENERATED_PATH)"
+	mkdir -p "$(DOCS_FOLDER)/$(DOCS_GENERATED_PATH)"
+	go run ./cmd/docs --app_data-path "$(DOCS_FOLDER)/$(DOCS_GENERATED_PATH)" --target new
+	git -C $(DOCS_FOLDER) add -A "$(DOCS_GENERATED_PATH)"
 
 .PHONY: docs-pr
 docs-pr: docs-commands-data

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docs-commands-data: docs
 	git -C $(DOCS_FOLDER) pull --ff-only origin $(DOCS_BRANCH)
 	rm -rf "$(DOCS_FOLDER)/$(DOCS_GENERATED_PATH)"
 	mkdir -p "$(DOCS_FOLDER)/$(DOCS_GENERATED_PATH)"
-	go run ./cmd/docs --app_data-path "$(DOCS_FOLDER)/$(DOCS_GENERATED_PATH)" --target new
+	go run ./cmd/docs --app_data-path "$(DOCS_FOLDER)/$(DOCS_GENERATED_PATH)"
 	git -C $(DOCS_FOLDER) add -A "$(DOCS_GENERATED_PATH)"
 
 .PHONY: docs-pr

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,12 +2,12 @@ version: 3
 output: prefixed
 dotenv: [.env]
 vars:
-  # The URL to the "old" Algolia docs repo
-  docs_remote: https://github.com/algolia/doc.git
-  # The temporary folder for the generated YML files
+  # The URL to the current Algolia docs repo
+  docs_remote: https://github.com/algolia/docs-new.git
   docs_local: docs
-  cli_ref_path: app_data/cli/commands
-  yml_folder: tmp
+  cli_ref_path: doc/tools/cli/commands
+  # The temporary folder for the generated MDX files
+  docs_output_dir: tmp
 tasks:
   build:
     desc: Build the binary
@@ -103,23 +103,23 @@ tasks:
     internal: true
     cmd: git clone --depth=1 {{ .docs_remote }} {{ .docs_local }}
   generate-command-reference:
-    desc: Generate updated YML files for the CLI command reference
+    desc: Generate updated MDX files for the CLI command reference
     internal: true
-    cmd: go run ./cmd/docs --app_data-path {{ .yml_folder }}
+    cmd: go run ./cmd/docs --app_data-path {{ .docs_output_dir }} --target new
   update-command-reference:
-    desc: Add the updated YML files to the docs
+    desc: Add the updated MDX files to the docs
     summary: |
       This task clones the Algolia docs repo,
-      adds the updated CLI reference yml files to it,
+      adds the updated CLI reference mdx files to it,
       and pushes a new PR to the GitHub repo.
     internal: true
     cmds:
       - |
         git -C {{ .docs_local }} checkout -B chore/cli-$(git rev-parse --short HEAD)
-        git -C {{ .docs_local }} rm "{{ .cli_ref_path }}/*.yml"
+        rm -rf {{ .docs_local }}/{{ .cli_ref_path }}
         mkdir -p {{ .docs_local }}/{{ .cli_ref_path }}
-        mv {{ .yml_folder }}/*.yml {{ .docs_local }}/{{ .cli_ref_path }}/
-        git -C {{ .docs_local }} add "{{ .cli_ref_path }}/*.yml"
+        mv {{ .docs_output_dir }}/* {{ .docs_local }}/{{ .cli_ref_path }}/
+        git -C {{ .docs_local }} add -A {{ .cli_ref_path }}
         git -C {{ .docs_local }} commit --message 'chore: Update CLI command reference'
     env:
       GIT_COMMITTER_NAME: algolia-ci
@@ -129,4 +129,4 @@ tasks:
   cleanup:
     desc: Cleanup the docs files
     internal: true
-    cmd: rm -rf {{ .docs_local }} {{ .yml_folder }} || true
+    cmd: rm -rf {{ .docs_local }} {{ .docs_output_dir }} || true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,7 +105,7 @@ tasks:
   generate-command-reference:
     desc: Generate updated MDX files for the CLI command reference
     internal: true
-    cmd: go run ./cmd/docs --app_data-path {{ .docs_output_dir }} --target new
+    cmd: go run ./cmd/docs --app_data-path {{ .docs_output_dir }}
   update-command-reference:
     desc: Add the updated MDX files to the docs
     summary: |

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -30,14 +30,8 @@ func run(args []string) error {
 		"Path directory where you want generate documentation data files",
 	)
 	help := flags.BoolP("help", "h", false, "Help about any command")
-	target := flags.StringP("target", "T", "new", "target old or new documentation website")
-
 	if err := flags.Parse(args); err != nil {
 		return err
-	}
-
-	if *target != "old" && *target != "new" {
-		return fmt.Errorf("error: --target can only be 'old' or 'new' ('new' by default)")
 	}
 
 	if *help {
@@ -60,14 +54,8 @@ func run(args []string) error {
 		return err
 	}
 
-	if *target == "old" {
-		if err := docs.GenYamlTree(rootCmd, *dir); err != nil {
-			return err
-		}
-	} else {
-		if err := docs.GenMdxTree(rootCmd, *dir); err != nil {
-			return err
-		}
+	if err := docs.GenMdxTree(rootCmd, *dir); err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -30,14 +30,14 @@ func run(args []string) error {
 		"Path directory where you want generate documentation data files",
 	)
 	help := flags.BoolP("help", "h", false, "Help about any command")
-	target := flags.StringP("target", "T", "old", "target old or new documentation website")
-
-	if *target != "old" && *target != "new" {
-		return fmt.Errorf("error: --destination can only be 'old' or 'new' ('old' by default)")
-	}
+	target := flags.StringP("target", "T", "new", "target old or new documentation website")
 
 	if err := flags.Parse(args); err != nil {
 		return err
+	}
+
+	if *target != "old" && *target != "new" {
+		return fmt.Errorf("error: --target can only be 'old' or 'new' ('new' by default)")
 	}
 
 	if *help {

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -118,15 +118,7 @@ func getCommands(cmd *cobra.Command) []Command {
 		}
 		command := newCommand(c)
 		if c.HasAvailableSubCommands() {
-			for _, s := range c.Commands() {
-				sub := newCommand(s)
-				if s.HasAvailableSubCommands() {
-					for _, sus := range s.Commands() {
-						sub.SubCommands = append(sub.SubCommands, newCommand(sus))
-					}
-				}
-				command.SubCommands = append(command.SubCommands, sub)
-			}
+			command.SubCommands = getCommands(c)
 		}
 		commands = append(commands, command)
 	}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -176,20 +176,23 @@ type Example struct {
 }
 
 func (cmd Command) ExamplesList() []Example {
-	var examples []Example
-	examplesRaw := strings.Split(cmd.Examples, "#")
-	for _, example := range examplesRaw {
-		example = strings.TrimSpace(example)
-		if len(example) == 0 {
-			continue
-		}
-		exampleLines := strings.Split(example, "\n")
+	type exampleBuilder struct {
+		desc      string
+		codeLines []string
+	}
 
-		code := strings.ReplaceAll(exampleLines[1], "$", "")
-		code = strings.TrimSpace(code)
+	var examples []Example
+	current := exampleBuilder{}
+
+	flush := func() {
+		code := strings.TrimSpace(strings.Join(current.codeLines, "\n"))
+		if code == "" {
+			current = exampleBuilder{}
+			return
+		}
 
 		formattedExample := Example{
-			Desc: strings.Replace(exampleLines[0], "#", "", 1),
+			Desc: current.desc,
 			Code: code,
 		}
 		if cmd.RunInWebCLI &&
@@ -202,6 +205,40 @@ func (cmd Command) ExamplesList() []Example {
 		}
 
 		examples = append(examples, formattedExample)
+		current = exampleBuilder{}
 	}
+
+	for _, rawLine := range strings.Split(cmd.Examples, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			if len(current.codeLines) > 0 {
+				flush()
+			}
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "#"):
+			flush()
+			current.desc = strings.TrimSpace(strings.TrimPrefix(line, "#"))
+		case strings.HasPrefix(line, "$"):
+			if current.desc == "" && len(current.codeLines) > 0 {
+				flush()
+			}
+			current.codeLines = append(
+				current.codeLines,
+				strings.TrimSpace(strings.TrimPrefix(line, "$")),
+			)
+		case len(current.codeLines) > 0:
+			current.codeLines = append(current.codeLines, line)
+		case current.desc == "":
+			current.desc = line
+		default:
+			current.desc += "\n" + line
+		}
+	}
+
+	flush()
+
 	return examples
 }

--- a/internal/docs/mdx.go
+++ b/internal/docs/mdx.go
@@ -1,7 +1,7 @@
 package docs
 
 import (
-	"fmt"
+	_ "embed"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,31 +10,85 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const mdxDocsRootSlug = "tools/cli/commands"
+
+//go:embed mdx.tpl
+var mdxTemplate string
+
+type mdxPage struct {
+	Command
+	Slug     string
+	SubPages []mdxPage
+}
+
 func GenMdxTree(cmd *cobra.Command, dir string) error {
 	tpl, err := template.New("mdx.tpl").Funcs(template.FuncMap{
 		"getExamples": func(cmd Command) []Example {
 			return cmd.ExamplesList()
 		},
-	}).ParseFiles("internal/docs/mdx.tpl")
+	}).Parse(mdxTemplate)
 	if err != nil {
 		return err
 	}
 
-	commands := getCommands(cmd)
+	return writeMdxPageTree(tpl, dir, newMdxPage(describeCommand(cmd)))
+}
 
-	for _, c := range commands {
-		c.Slug = strings.ReplaceAll(c.Name, " ", "-")
-		filename := filepath.Join(dir, fmt.Sprintf("%s.mdx", c.Slug))
-		file, err := os.Create(filename)
-		if err != nil {
-			return err
-		}
+func newMdxPage(cmd Command) mdxPage {
+	page := mdxPage{
+		Command: cmd,
+		Slug:    buildMdxSlug(commandPathParts(cmd)),
+	}
 
-		err = tpl.Execute(file, c)
-		if err != nil {
+	for _, subCommand := range cmd.SubCommands {
+		page.SubPages = append(page.SubPages, newMdxPage(subCommand))
+	}
+
+	return page
+}
+
+func writeMdxPageTree(tpl *template.Template, dir string, page mdxPage) error {
+	filename := filepath.Join(dir, commandOutputDir(page.Command), "index.mdx")
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
+		return err
+	}
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if err := tpl.Execute(file, page); err != nil {
+		return err
+	}
+
+	for _, subPage := range page.SubPages {
+		if err := writeMdxPageTree(tpl, dir, subPage); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func commandPathParts(cmd Command) []string {
+	parts := strings.Fields(cmd.Name)
+	if len(parts) <= 1 {
+		return nil
+	}
+
+	return parts[1:]
+}
+
+func commandOutputDir(cmd Command) string {
+	return filepath.Join(commandPathParts(cmd)...)
+}
+
+func buildMdxSlug(parts []string) string {
+	if len(parts) == 0 {
+		return mdxDocsRootSlug
+	}
+
+	return mdxDocsRootSlug + "/" + strings.Join(parts, "/")
 }

--- a/internal/docs/mdx.tpl
+++ b/internal/docs/mdx.tpl
@@ -4,72 +4,49 @@ title: |-
   {{ .Name }}
 description: |-
   {{ .Description }}
-slug: tools/cli/commands/{{ .Slug }}
+slug: {{ .Slug }}
 ---
-{{ if .SubCommands }}{{ range $subCommand := .SubCommands }}{{ if $subCommand.SubCommands }}{{ range $susCommand := $subCommand.SubCommands}}
-## {{ $susCommand.Name }}
-
-{{ $susCommand.Description }}
-
-### Usage
-
-`{{ $susCommand.Usage }}`
-
-{{ $examples := getExamples $susCommand }}{{ if $examples }}
-### Examples
-{{ range $example := $examples }}{{ $example.Desc }}
-
-```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
-{{ $example.Code }}
-```
-{{ end }}{{ end }}{{ range $flagKey, $flagSlice := $susCommand.Flags }}{{ if $flagSlice }}
-### Flags 
-{{ range $flag := $flagSlice }}
-- {{ if $flag.Shorthand }}`-{{ $flag.Shorthand }}`, {{ end }}`--{{ $flag.Name }}`: {{ $flag.Description }}
-{{ end }}{{ end }}{{ end }}{{ end }}
-{{ else }}
-## {{ $subCommand.Name }}
-
-{{ $subCommand.Description }}
-
-### Usage
-
-`{{ $subCommand.Usage }}`
-
-{{ $examples := getExamples $subCommand }}
-{{ if $examples }}
-### Examples
-{{ range $example := $examples }}
-{{ $example.Desc }}
-
-```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
-{{ $example.Code }}
-```
-{{ end }}
+{{ if .Description }}
+{{ .Description }}
 {{ end }}
 
-{{ range $flagKey, $flagSlice := $subCommand.Flags }}
-{{ if $flagSlice }}
-### Flags 
-{{ range $flag := $flagSlice }}
-- {{ if $flag.Shorthand }}`-{{ $flag.Shorthand }}`, {{ end }}`--{{ $flag.Name }}`: {{ $flag.Description }}
-{{ end }}{{ end }}{{ end }}{{ end}}{{ end }}
-{{ else }}## {{ .Name }}
-
-### Usage
+## Usage
 
 `{{ .Usage }}`
-{{ $examples := getExamples . }}{{ if $examples }}
-### Examples
+
+{{ if .Aliases }}
+## Aliases
+
+{{ range $alias := .Aliases -}}
+- `{{ $alias }}`
+{{ end }}
+{{ end }}
+
+{{ if .SubPages }}
+## Subcommands
+
+{{ range $subPage := .SubPages -}}
+- [`{{ $subPage.Name }}`](/{{ $subPage.Slug }}): {{ $subPage.Description }}
+{{ end }}
+{{ end }}
+
+{{ $examples := getExamples .Command }}{{ if $examples }}
+## Examples
 {{ range $example := $examples }}
 {{ $example.Desc }}
 
-```sh {{ if $example.WebCLICommand }}command="{{$example.WebCLICommand}}"{{ end }}
+```sh{{ if $example.WebCLICommand }} command="{{$example.WebCLICommand}}"{{ end }}
 {{ $example.Code }}
 ```
-{{ end }}{{ end }}
-{{ range $flagKey, $flagSlice := .Flags }}
-### {{ $flagKey }}
-{{ range $flag := $flagSlice }}
+{{ end }}
+{{ end }}
+
+{{ range $flagKey, $flagSlice := .Flags -}}
+{{ if $flagSlice }}
+## {{ $flagKey }}
+
+{{ range $flag := $flagSlice -}}
 - {{ if $flag.Shorthand }}`-{{ $flag.Shorthand }}`, {{ end }}`--{{ $flag.Name }}`: {{ $flag.Description }}
-{{ end }}{{ end }}{{ end }}
+{{ end }}
+{{ end }}
+{{ end }}

--- a/internal/docs/mdx_integration_test.go
+++ b/internal/docs/mdx_integration_test.go
@@ -1,0 +1,36 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/internal/docs"
+	"github.com/algolia/cli/pkg/cmd/root"
+	clitest "github.com/algolia/cli/test"
+)
+
+func TestGenMdxTreeSupportsCurrentCommandTree(t *testing.T) {
+	f, _ := clitest.NewFactory(false, nil, nil, "")
+	rootCmd := root.NewRootCmd(f)
+
+	dir := t.TempDir()
+	require.NoError(t, docs.GenMdxTree(rootCmd, dir))
+
+	rootContent := readTestFile(t, filepath.Join(dir, "index.mdx"))
+	require.Contains(t, rootContent, "algolia search MOVIES --query \"toy story\"")
+
+	logoutContent := readTestFile(t, filepath.Join(dir, "auth", "logout", "index.mdx"))
+	require.Contains(t, logoutContent, "algolia auth logout")
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return string(content)
+}

--- a/internal/docs/mdx_test.go
+++ b/internal/docs/mdx_test.go
@@ -1,0 +1,84 @@
+package docs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCommandsRecursivelyIncludesNestedCommands(t *testing.T) {
+	root := &cobra.Command{Use: "algolia", Short: "Algolia CLI"}
+	one := &cobra.Command{Use: "one", Short: "Level one"}
+	two := &cobra.Command{Use: "two", Short: "Level two"}
+	three := &cobra.Command{Use: "three", Short: "Level three"}
+	four := &cobra.Command{
+		Use:   "four",
+		Short: "Level four",
+		RunE: func(*cobra.Command, []string) error {
+			return nil
+		},
+	}
+
+	three.AddCommand(four)
+	two.AddCommand(three)
+	one.AddCommand(two)
+	root.AddCommand(one)
+
+	commands := getCommands(root)
+	require.Len(t, commands, 1)
+	require.Len(t, commands[0].SubCommands, 1)
+	require.Len(t, commands[0].SubCommands[0].SubCommands, 1)
+	require.Len(t, commands[0].SubCommands[0].SubCommands[0].SubCommands, 1)
+	require.Equal(
+		t,
+		"algolia one two three four",
+		commands[0].SubCommands[0].SubCommands[0].SubCommands[0].Name,
+	)
+}
+
+func TestGenMdxTreeWritesNestedCommandPages(t *testing.T) {
+	root := &cobra.Command{Use: "algolia", Short: "Algolia CLI"}
+	events := &cobra.Command{Use: "events", Short: "Manage events"}
+	sources := &cobra.Command{Use: "sources", Short: "Manage event sources"}
+	list := &cobra.Command{
+		Use:     "list",
+		Short:   "List event sources",
+		Example: "# List sources\n$ algolia events sources list",
+		RunE: func(*cobra.Command, []string) error {
+			return nil
+		},
+	}
+	list.Flags().StringP("format", "F", "json", "Output format")
+
+	sources.AddCommand(list)
+	events.AddCommand(sources)
+	root.AddCommand(events)
+
+	dir := t.TempDir()
+	require.NoError(t, GenMdxTree(root, dir))
+
+	rootContent := readTestFile(t, filepath.Join(dir, "index.mdx"))
+	require.Contains(t, rootContent, "slug: tools/cli/commands")
+	require.Contains(t, rootContent, "[`algolia events`](/tools/cli/commands/events)")
+
+	eventsContent := readTestFile(t, filepath.Join(dir, "events", "index.mdx"))
+	require.Contains(t, eventsContent, "slug: tools/cli/commands/events")
+	require.Contains(t, eventsContent, "[`algolia events sources`](/tools/cli/commands/events/sources)")
+
+	listContent := readTestFile(t, filepath.Join(dir, "events", "sources", "list", "index.mdx"))
+	require.Contains(t, listContent, "slug: tools/cli/commands/events/sources/list")
+	require.Contains(t, listContent, "`algolia events sources list [flags]`")
+	require.Contains(t, listContent, "`-F`, `--format`")
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return string(content)
+}

--- a/internal/docs/mdx_test.go
+++ b/internal/docs/mdx_test.go
@@ -74,6 +74,56 @@ func TestGenMdxTreeWritesNestedCommandPages(t *testing.T) {
 	require.Contains(t, listContent, "`-F`, `--format`")
 }
 
+func TestGenMdxTreeSupportsCodeOnlyExamples(t *testing.T) {
+	root := &cobra.Command{
+		Use:   "algolia",
+		Short: "Algolia CLI",
+		Example: `
+$ algolia search MOVIES --query "toy story"
+$ algolia objects browse MOVIES
+`,
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, GenMdxTree(root, dir))
+
+	rootContent := readTestFile(t, filepath.Join(dir, "index.mdx"))
+	require.Contains(t, rootContent, "## Examples")
+	require.Contains(t, rootContent, "algolia search MOVIES --query \"toy story\"")
+	require.Contains(t, rootContent, "algolia objects browse MOVIES")
+}
+
+func TestExamplesListParsesMixedExampleFormats(t *testing.T) {
+	cmd := Command{
+		Examples: `
+# Describe a command
+$ algolia describe search
+
+$ algolia auth logout
+$ algolia profile list
+
+# Wrapped command
+$ algolia search MOVIES \
+  --query "toy story"
+`,
+	}
+
+	examples := cmd.ExamplesList()
+	require.Len(t, examples, 4)
+
+	require.Equal(t, "Describe a command", examples[0].Desc)
+	require.Equal(t, "algolia describe search", examples[0].Code)
+
+	require.Empty(t, examples[1].Desc)
+	require.Equal(t, "algolia auth logout", examples[1].Code)
+
+	require.Empty(t, examples[2].Desc)
+	require.Equal(t, "algolia profile list", examples[2].Code)
+
+	require.Equal(t, "Wrapped command", examples[3].Desc)
+	require.Equal(t, "algolia search MOVIES \\\n--query \"toy story\"", examples[3].Code)
+}
+
 func readTestFile(t *testing.T, path string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary [GROUT-177](https://algolia.atlassian.net/browse/GROUT-177)
- update release automation to open docs PRs against `algolia/docs-new`
- generate nested MDX command pages under `doc/tools/cli/commands` instead of flat YAML files
- add focused coverage for recursive command traversal and nested MDX output

## Test plan
- [x] `go test ./cmd/docs ./internal/docs ./pkg/cmd/describe`


[GROUT-177]: https://algolia.atlassian.net/browse/GROUT-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ