### PR TITLE
feat: add CompositionClient to cli and bump SDK to v4.38.0

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -153,3 +153,8 @@ func TestSearch(t *testing.T) {
 func TestAgentReady(t *testing.T) {
 	runTestsInDir(t, "testscripts/agent-ready")
 }
+
+// TestCompositions tests `algolia compositions` commands
+func TestCompositions(t *testing.T) {
+	runTestsInDir(t, "testscripts/compositions")
+}

--- a/e2e/testscripts/compositions/compositions.txtar
+++ b/e2e/testscripts/compositions/compositions.txtar
@@ -1,0 +1,94 @@
+env COMP_ID=test-comp-e2e
+env INDEX_NAME=test-comp-source-index
+
+# Add a record to the source index so the composition has something to search
+exec algolia records import ${INDEX_NAME} --file record.json --wait
+! stderr .
+
+# Defer index cleanup
+defer algolia index delete ${INDEX_NAME} --confirm
+! stderr .
+
+# Upsert a composition using the real behavior.injection schema
+exec algolia compositions upsert ${COMP_ID} --file comp.json
+! stderr .
+stdout '"taskID"'
+
+# Defer composition cleanup
+defer algolia compositions delete ${COMP_ID} --confirm
+! stderr .
+
+# Get the composition back
+exec algolia compositions get ${COMP_ID}
+! stderr .
+stdout ${COMP_ID}
+
+# List compositions (should contain our composition)
+exec algolia compositions list
+! stderr .
+stdout ${COMP_ID}
+
+# Search the composition
+exec algolia compositions search ${COMP_ID} "test"
+! stderr .
+stdout '"hits"'
+
+# Upsert a rule
+exec algolia compositions rules upsert ${COMP_ID} rule-e2e --file rule.json
+! stderr .
+stdout '"taskID"'
+
+# Get the rule back
+exec algolia compositions rules get ${COMP_ID} rule-e2e
+! stderr .
+stdout 'rule-e2e'
+
+# List rules
+exec algolia compositions rules list ${COMP_ID}
+! stderr .
+stdout 'rule-e2e'
+
+# Delete the rule
+exec algolia compositions rules delete ${COMP_ID} rule-e2e --confirm
+! stderr .
+
+-- record.json --
+{"objectID": "test-record-1", "name": "Test record"}
+
+-- comp.json --
+{
+  "objectID": "test-comp-e2e",
+  "name": "Test Composition E2E",
+  "behavior": {
+    "injection": {
+      "main": {
+        "source": {
+          "search": {
+            "index": "test-comp-source-index"
+          }
+        }
+      }
+    }
+  }
+}
+
+-- rule.json --
+{
+  "objectID": "rule-e2e",
+  "conditions": [
+    { "anchoring": "is", "pattern": "test" }
+  ],
+  "consequence": {
+    "behavior": {
+      "injection": {
+        "main": {
+          "source": {
+            "search": {
+              "index": "test-comp-source-index"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/BurntSushi/toml v1.4.0
 	github.com/MakeNowJust/heredoc v1.0.0
-	github.com/algolia/algoliasearch-client-go/v4 v4.35.0
+	github.com/algolia/algoliasearch-client-go/v4 v4.38.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/briandowns/spinner v1.23.2
 	github.com/cli/go-internal v0.0.0-20241025142207-6c48bcd5ce24

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,10 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/algolia/algoliasearch-client-go/v4 v4.35.0 h1:CfckAd2ok/c7/U7MoY3HLW8FeMeAYVBAUFty/d/rxss=
-github.com/algolia/algoliasearch-client-go/v4 v4.35.0/go.mod h1:2bHeze2/5+jvT8IYVq8j2NDLr/4R6erGxgud7ESuXww=
+github.com/algolia/algoliasearch-client-go/v4 v4.37.2 h1:Iqwb/mx9mVKKWKo8qildTAK36RTLIhFNuufqkhBmiHM=
+github.com/algolia/algoliasearch-client-go/v4 v4.37.2/go.mod h1:2bHeze2/5+jvT8IYVq8j2NDLr/4R6erGxgud7ESuXww=
+github.com/algolia/algoliasearch-client-go/v4 v4.38.0 h1:ufPpfevxC7DN9vTt9niVc7MvV6inrq8zHpIiTvp2lXI=
+github.com/algolia/algoliasearch-client-go/v4 v4.38.0/go.mod h1:2bHeze2/5+jvT8IYVq8j2NDLr/4R6erGxgud7ESuXww=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=

--- a/pkg/cmd/compositions/compositions.go
+++ b/pkg/cmd/compositions/compositions.go
@@ -1,0 +1,30 @@
+package compositions
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmd/compositions/delete"
+	"github.com/algolia/cli/pkg/cmd/compositions/get"
+	"github.com/algolia/cli/pkg/cmd/compositions/list"
+	"github.com/algolia/cli/pkg/cmd/compositions/rules"
+	compsearch "github.com/algolia/cli/pkg/cmd/compositions/search"
+	"github.com/algolia/cli/pkg/cmd/compositions/upsert"
+	"github.com/algolia/cli/pkg/cmdutil"
+)
+
+// NewCompositionsCmd returns the compositions command group.
+func NewCompositionsCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "compositions",
+		Short: "Manage Algolia Compositions",
+		Long:  "Create, retrieve, update, delete, and search Algolia Compositions.",
+	}
+
+	cmd.AddCommand(list.NewListCmd(f))
+	cmd.AddCommand(get.NewGetCmd(f))
+	cmd.AddCommand(upsert.NewUpsertCmd(f))
+	cmd.AddCommand(delete.NewDeleteCmd(f))
+	cmd.AddCommand(compsearch.NewSearchCmd(f))
+	cmd.AddCommand(rules.NewRulesCmd(f))
+	return cmd
+}

--- a/pkg/cmd/compositions/delete/delete.go
+++ b/pkg/cmd/compositions/delete/delete.go
@@ -52,6 +52,9 @@ func NewDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 			opts.CompositionID = args[0]
 
 			if !opts.DoConfirm {
+				if !opts.IO.CanPrompt() {
+					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
+				}
 				var confirmed bool
 				err := prompt.Confirm(
 					fmt.Sprintf("Delete composition %q?", opts.CompositionID),
@@ -61,7 +64,7 @@ func NewDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 					return fmt.Errorf("failed to prompt: %w", err)
 				}
 				if !confirmed {
-					return cmdutil.ErrCancel
+					return nil
 				}
 			}
 
@@ -100,6 +103,11 @@ func runDeleteCmd(opts *DeleteOptions) error {
 
 	if err := compinternal.WaitForTask(opts.IO, client, opts.CompositionID, res.TaskID, compinternal.PollInterval, compinternal.Timeout); err != nil {
 		return err
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(opts.IO.Out, "%s Deleted composition %s\n", cs.SuccessIcon(), opts.CompositionID)
 	}
 
 	return p.Print(opts.IO, res)

--- a/pkg/cmd/compositions/delete/delete.go
+++ b/pkg/cmd/compositions/delete/delete.go
@@ -1,0 +1,106 @@
+package delete
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/prompt"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// DeleteOptions holds the dependencies and flags for the delete command.
+type DeleteOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	CompositionID     string
+	DoConfirm         bool
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewDeleteCmd returns the `compositions delete` command.
+func NewDeleteCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &DeleteOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete <composition-id>",
+		Short: "Delete a composition",
+		Args:  validators.ExactArgsWithMsg(1, "compositions delete requires a <composition-id> argument."),
+		Annotations: map[string]string{
+			"acls": "editSettings",
+		},
+		Example: heredoc.Doc(`
+			# Delete a composition (with confirmation prompt)
+			$ algolia compositions delete my-comp
+
+			# Delete without confirmation
+			$ algolia compositions delete my-comp --confirm
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.CompositionID = args[0]
+
+			if !opts.DoConfirm {
+				var confirmed bool
+				err := prompt.Confirm(
+					fmt.Sprintf("Delete composition %q?", opts.CompositionID),
+					&confirmed,
+				)
+				if err != nil {
+					return fmt.Errorf("failed to prompt: %w", err)
+				}
+				if !confirmed {
+					return cmdutil.ErrCancel
+				}
+			}
+
+			return runDeleteCmd(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.DoConfirm, "confirm", "y", false, "Skip confirmation prompt")
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runDeleteCmd(opts *DeleteOptions) error {
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Deleting composition")
+
+	res, err := client.DeleteComposition(
+		client.NewApiDeleteCompositionRequest(opts.CompositionID),
+	)
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	if err := compinternal.WaitForTask(opts.IO, client, opts.CompositionID, res.TaskID, compinternal.PollInterval, compinternal.Timeout); err != nil {
+		return err
+	}
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/delete/delete_test.go
+++ b/pkg/cmd/compositions/delete/delete_test.go
@@ -1,0 +1,88 @@
+package delete_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/cmd/compositions/delete"
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+func TestDeleteComposition(t *testing.T) {
+	r := &httpmock.Registry{}
+	r.Register(httpmock.REST("DELETE", "1/compositions/my-comp"), httpmock.StringResponse(`{"taskID":99}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/99"), httpmock.StringResponse(`{"status":"published"}`))
+
+	compinternal.PollInterval = 1 * time.Millisecond
+	compinternal.Timeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		compinternal.PollInterval = compinternal.DefaultPollInterval
+		compinternal.Timeout = compinternal.DefaultTimeout
+	})
+
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := delete.NewDeleteCmd(f)
+	_, err := test.Execute(cmd, "my-comp --confirm", out)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"taskID":99}`, strings.TrimSpace(out.String()))
+	r.Verify(t)
+}
+
+func TestDeleteComposition_WaitsForPublished(t *testing.T) {
+	// Verifies polling continues through successive notPublished states.
+	r := &httpmock.Registry{}
+	r.Register(httpmock.REST("DELETE", "1/compositions/my-comp"), httpmock.StringResponse(`{"taskID":77}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/77"), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/77"), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/77"), httpmock.StringResponse(`{"status":"published"}`))
+
+	compinternal.PollInterval = 1 * time.Millisecond
+	compinternal.Timeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		compinternal.PollInterval = compinternal.DefaultPollInterval
+		compinternal.Timeout = compinternal.DefaultTimeout
+	})
+
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := delete.NewDeleteCmd(f)
+	_, err := test.Execute(cmd, "my-comp --confirm", out)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"taskID":77}`, strings.TrimSpace(out.String()))
+	r.Verify(t)
+
+	taskPolls := 0
+	for _, req := range r.Requests {
+		if strings.Contains(req.URL.Path, "/task/") {
+			taskPolls++
+		}
+	}
+	assert.Equal(t, 3, taskPolls, "expected 3 task status polls (2x notPublished + 1x published)")
+}
+
+func TestDeleteComposition_RequiresConfirmation(t *testing.T) {
+	// Without --confirm on a non-TTY, the prompt must fail and no HTTP request must be made.
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := delete.NewDeleteCmd(f)
+	_, err := test.Execute(cmd, "my-comp", out)
+	require.Error(t, err)
+	assert.Empty(t, out.String())
+	assert.Empty(t, r.Requests)
+}
+
+func TestDeleteComposition_MissingArg(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := delete.NewDeleteCmd(f)
+	_, err := test.Execute(cmd, "", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a <composition-id> argument")
+}

--- a/pkg/cmd/compositions/get/get.go
+++ b/pkg/cmd/compositions/get/get.go
@@ -1,0 +1,75 @@
+package get
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// GetOptions holds the dependencies and flags for the get command.
+type GetOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	CompositionID     string
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewGetCmd returns the `compositions get` command.
+func NewGetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &GetOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get <composition-id>",
+		Short: "Get a composition by ID",
+		Args:  validators.ExactArgsWithMsg(1, "compositions get requires a <composition-id> argument."),
+		Annotations: map[string]string{
+			"acls": "search",
+		},
+		Example: heredoc.Doc(`
+			# Get the composition with ID "my-comp"
+			$ algolia compositions get my-comp
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.CompositionID = args[0]
+			return runGetCmd(opts)
+		},
+	}
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runGetCmd(opts *GetOptions) error {
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Fetching composition")
+
+	res, err := client.GetComposition(client.NewApiGetCompositionRequest(opts.CompositionID))
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/get/get_test.go
+++ b/pkg/cmd/compositions/get/get_test.go
@@ -1,0 +1,56 @@
+package get_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/cmd/compositions/get"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+func TestGetComposition(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		mock    string
+		wantOut string
+	}{
+		{
+			name:    "composition with injection behavior",
+			cli:     "my-comp",
+			mock:    `{"objectID":"my-comp","name":"My Comp","behavior":{"injection":{"main":{}}}}`,
+			wantOut: `{"behavior":{"injection":{"main":{}}},"name":"My Comp","objectID":"my-comp"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &httpmock.Registry{}
+			r.Register(
+				httpmock.REST("GET", "1/compositions/my-comp"),
+				httpmock.StringResponse(tt.mock),
+			)
+
+			f, out := test.NewFactory(false, r, nil, "")
+			cmd := get.NewGetCmd(f)
+			_, err := test.Execute(cmd, tt.cli, out)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, tt.wantOut, strings.TrimSpace(out.String()))
+			r.Verify(t)
+		})
+	}
+}
+
+func TestGetComposition_MissingArg(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := get.NewGetCmd(f)
+	_, err := test.Execute(cmd, "", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a <composition-id> argument")
+}

--- a/pkg/cmd/compositions/internal/wait.go
+++ b/pkg/cmd/compositions/internal/wait.go
@@ -39,6 +39,18 @@ func WaitForTask(
 	io.StartProgressIndicatorWithLabel("Waiting for task")
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+
+	// Check once immediately so quick-completing tasks don't wait a full pollInterval.
+	resp, err := client.GetTask(client.NewApiGetTaskRequest(compositionID, taskID))
+	if err != nil {
+		io.StopProgressIndicator()
+		return err
+	}
+	if resp.Status == algoliaComposition.TASK_STATUS_PUBLISHED {
+		io.StopProgressIndicator()
+		return nil
+	}
+
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/cmd/compositions/internal/wait.go
+++ b/pkg/cmd/compositions/internal/wait.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+
+	"github.com/algolia/cli/pkg/iostreams"
+)
+
+const (
+	// DefaultPollInterval is how often WaitForTask checks task status in production.
+	DefaultPollInterval = 2 * time.Second
+	// DefaultTimeout is the maximum time WaitForTask will wait before giving up.
+	DefaultTimeout = 2 * time.Minute
+)
+
+// PollInterval and Timeout are the active timing values used by WaitForTask.
+// Override these in tests to avoid slow polling; restore via t.Cleanup.
+var (
+	PollInterval = DefaultPollInterval
+	Timeout      = DefaultTimeout
+)
+
+// WaitForTask polls the Compositions API until the given task reaches PUBLISHED
+// status, then stops the progress indicator. pollInterval and timeout control
+// timing; use DefaultPollInterval and DefaultTimeout in production callers and
+// small values (e.g. 1ms / 50ms) in tests.
+func WaitForTask(
+	io *iostreams.IOStreams,
+	client *algoliaComposition.APIClient,
+	compositionID string,
+	taskID int64,
+	pollInterval time.Duration,
+	timeout time.Duration,
+) error {
+	io.StartProgressIndicatorWithLabel("Waiting for task")
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			io.StopProgressIndicator()
+			return fmt.Errorf("timed out waiting for task %d on composition %s: %w", taskID, compositionID, ctx.Err())
+		case <-ticker.C:
+			resp, err := client.GetTask(client.NewApiGetTaskRequest(compositionID, taskID))
+			if err != nil {
+				io.StopProgressIndicator()
+				return err
+			}
+			if resp.Status == algoliaComposition.TASK_STATUS_PUBLISHED {
+				io.StopProgressIndicator()
+				return nil
+			}
+			// TASK_STATUS_NOT_PUBLISHED (or any other non-terminal status): keep polling.
+		}
+	}
+}

--- a/pkg/cmd/compositions/internal/wait_test.go
+++ b/pkg/cmd/compositions/internal/wait_test.go
@@ -1,0 +1,109 @@
+package internal_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/test"
+)
+
+const (
+	testPollInterval = 1 * time.Millisecond
+	testTimeout      = 50 * time.Millisecond
+)
+
+// TestWaitForTask_ImmediatelyPublished verifies that WaitForTask returns nil
+// when the very first poll returns "published".
+func TestWaitForTask_ImmediatelyPublished(t *testing.T) {
+	r := &httpmock.Registry{}
+	r.Register(
+		httpmock.REST("GET", "1/compositions/my-comp/task/42"),
+		httpmock.StringResponse(`{"status":"published"}`),
+	)
+
+	f, _ := test.NewFactory(false, r, nil, "")
+	client, err := f.CompositionClient()
+	require.NoError(t, err)
+
+	io, _, _, _ := iostreams.Test()
+	err = compinternal.WaitForTask(io, client, "my-comp", 42, testPollInterval, testTimeout)
+	require.NoError(t, err)
+	r.Verify(t)
+}
+
+// TestWaitForTask_SuccessiveNotPublished verifies that WaitForTask keeps
+// polling through multiple "notPublished" responses before eventually
+// succeeding on "published".
+func TestWaitForTask_SuccessiveNotPublished(t *testing.T) {
+	r := &httpmock.Registry{}
+	taskPath := "1/compositions/my-comp/task/42"
+
+	// First two polls return notPublished; third returns published.
+	r.Register(httpmock.REST("GET", taskPath), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", taskPath), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", taskPath), httpmock.StringResponse(`{"status":"published"}`))
+
+	f, _ := test.NewFactory(false, r, nil, "")
+	client, err := f.CompositionClient()
+	require.NoError(t, err)
+
+	io, _, _, _ := iostreams.Test()
+	err = compinternal.WaitForTask(io, client, "my-comp", 42, testPollInterval, testTimeout)
+	require.NoError(t, err)
+
+	// All three stubs must have been consumed.
+	r.Verify(t)
+	assert.Len(t, r.Requests, 3, "expected exactly 3 GetTask requests")
+}
+
+// TestWaitForTask_Timeout verifies that WaitForTask returns an error containing
+// "timed out" when the task never reaches published within the timeout window.
+func TestWaitForTask_Timeout(t *testing.T) {
+	r := &httpmock.Registry{}
+	taskPath := "1/compositions/my-comp/task/42"
+
+	// Register more stubs than we expect to consume so the registry doesn't
+	// run out before the timeout fires.
+	for range 100 {
+		r.Register(httpmock.REST("GET", taskPath), httpmock.StringResponse(`{"status":"notPublished"}`))
+	}
+
+	f, _ := test.NewFactory(false, r, nil, "")
+	client, err := f.CompositionClient()
+	require.NoError(t, err)
+
+	io, _, _, _ := iostreams.Test()
+	err = compinternal.WaitForTask(io, client, "my-comp", 42, testPollInterval, testTimeout)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+	assert.Contains(t, err.Error(), "42")
+	assert.Contains(t, err.Error(), "my-comp")
+}
+
+// TestWaitForTask_APIError verifies that WaitForTask surfaces errors from the
+// GetTask API call immediately without retrying.
+func TestWaitForTask_APIError(t *testing.T) {
+	r := &httpmock.Registry{}
+	taskPath := "1/compositions/my-comp/task/42"
+
+	r.Register(
+		httpmock.REST("GET", taskPath),
+		httpmock.ErrorResponse(),
+	)
+
+	f, _ := test.NewFactory(false, r, nil, "")
+	client, err := f.CompositionClient()
+	require.NoError(t, err)
+
+	io, _, _, _ := iostreams.Test()
+	err = compinternal.WaitForTask(io, client, "my-comp", 42, testPollInterval, testTimeout)
+	require.Error(t, err)
+	// Only one request should have been made before returning.
+	assert.Len(t, r.Requests, 1, "expected WaitForTask to stop after first API error")
+}

--- a/pkg/cmd/compositions/list/list.go
+++ b/pkg/cmd/compositions/list/list.go
@@ -1,0 +1,71 @@
+package list
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+)
+
+// ListOptions holds the dependencies and flags for the list command.
+type ListOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewListCmd returns the `compositions list` command.
+func NewListCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &ListOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all compositions",
+		Annotations: map[string]string{
+			"acls": "search",
+		},
+		Example: heredoc.Doc(`
+			# List all compositions
+			$ algolia compositions list
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runListCmd(opts)
+		},
+	}
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runListCmd(opts *ListOptions) error {
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Fetching compositions")
+
+	res, err := client.ListCompositions(client.NewApiListCompositionsRequest())
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/list/list_test.go
+++ b/pkg/cmd/compositions/list/list_test.go
@@ -1,0 +1,50 @@
+package list_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/cmd/compositions/list"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+func TestListCompositions(t *testing.T) {
+	tests := []struct {
+		name    string
+		mock    string
+		wantOut string
+	}{
+		{
+			name:    "single composition",
+			mock:    `{"items":[{"objectID":"my-comp","name":"My Comp","behavior":{"injection":{"main":{}}}}],"nbPages":1,"page":0,"hitsPerPage":20,"nbHits":1}`,
+			wantOut: `{"hitsPerPage":20,"items":[{"behavior":{"injection":{"main":{}}},"name":"My Comp","objectID":"my-comp"}],"nbHits":1,"nbPages":1,"page":0}`,
+		},
+		{
+			name:    "empty list",
+			mock:    `{"items":[],"nbPages":0,"page":0,"hitsPerPage":20,"nbHits":0}`,
+			wantOut: `{"hitsPerPage":20,"items":[],"nbHits":0,"nbPages":0,"page":0}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &httpmock.Registry{}
+			r.Register(
+				httpmock.REST("GET", "1/compositions"),
+				httpmock.StringResponse(tt.mock),
+			)
+
+			f, out := test.NewFactory(false, r, nil, "")
+			cmd := list.NewListCmd(f)
+			_, err := test.Execute(cmd, "", out)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, tt.wantOut, strings.TrimSpace(out.String()))
+			r.Verify(t)
+		})
+	}
+}

--- a/pkg/cmd/compositions/rules/delete/delete.go
+++ b/pkg/cmd/compositions/rules/delete/delete.go
@@ -54,16 +54,19 @@ func NewDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 			opts.ObjectID = args[1]
 
 			if !opts.DoConfirm {
+				if !opts.IO.CanPrompt() {
+					return cmdutil.FlagErrorf("--confirm required when non-interactive shell is detected")
+				}
 				var confirmed bool
 				err := prompt.Confirm(
 					fmt.Sprintf("Delete rule %q from composition %q?", opts.ObjectID, opts.CompositionID),
 					&confirmed,
 				)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to prompt: %w", err)
 				}
 				if !confirmed {
-					return cmdutil.ErrCancel
+					return nil
 				}
 			}
 
@@ -100,6 +103,11 @@ func runDeleteCmd(opts *DeleteOptions) error {
 
 	if err := compinternal.WaitForTask(opts.IO, client, opts.CompositionID, res.TaskID, compinternal.PollInterval, compinternal.Timeout); err != nil {
 		return err
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(opts.IO.Out, "%s Deleted rule %s from composition %s\n", cs.SuccessIcon(), opts.ObjectID, opts.CompositionID)
 	}
 
 	return p.Print(opts.IO, res)

--- a/pkg/cmd/compositions/rules/delete/delete.go
+++ b/pkg/cmd/compositions/rules/delete/delete.go
@@ -1,0 +1,106 @@
+package delete
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/prompt"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// DeleteOptions holds dependencies and flags for the rules delete command.
+type DeleteOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	CompositionID     string
+	ObjectID          string
+	DoConfirm         bool
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewDeleteCmd returns the `compositions rules delete` command.
+func NewDeleteCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &DeleteOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete <composition-id> <rule-id>",
+		Short: "Delete a composition rule",
+		Args:  validators.ExactArgsWithMsg(2, "compositions rules delete requires a <composition-id> and a <rule-id> argument."),
+		Annotations: map[string]string{
+			"acls": "editSettings",
+		},
+		Example: heredoc.Doc(`
+			# Delete a rule (with confirmation prompt)
+			$ algolia compositions rules delete my-comp rule-1
+
+			# Delete without confirmation
+			$ algolia compositions rules delete my-comp rule-1 --confirm
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.CompositionID = args[0]
+			opts.ObjectID = args[1]
+
+			if !opts.DoConfirm {
+				var confirmed bool
+				err := prompt.Confirm(
+					fmt.Sprintf("Delete rule %q from composition %q?", opts.ObjectID, opts.CompositionID),
+					&confirmed,
+				)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					return cmdutil.ErrCancel
+				}
+			}
+
+			return runDeleteCmd(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.DoConfirm, "confirm", "y", false, "Skip confirmation prompt")
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runDeleteCmd(opts *DeleteOptions) error {
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Deleting rule")
+
+	res, err := client.DeleteCompositionRule(client.NewApiDeleteCompositionRuleRequest(opts.CompositionID, opts.ObjectID))
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	if err := compinternal.WaitForTask(opts.IO, client, opts.CompositionID, res.TaskID, compinternal.PollInterval, compinternal.Timeout); err != nil {
+		return err
+	}
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/rules/delete/delete_test.go
+++ b/pkg/cmd/compositions/rules/delete/delete_test.go
@@ -1,0 +1,88 @@
+package delete_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/cmd/compositions/rules/delete"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+func TestDeleteRule(t *testing.T) {
+	r := &httpmock.Registry{}
+	r.Register(httpmock.REST("DELETE", "1/compositions/my-comp/rules/rule-1"), httpmock.StringResponse(`{"taskID":77}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/77"), httpmock.StringResponse(`{"status":"published"}`))
+
+	compinternal.PollInterval = 1 * time.Millisecond
+	compinternal.Timeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		compinternal.PollInterval = compinternal.DefaultPollInterval
+		compinternal.Timeout = compinternal.DefaultTimeout
+	})
+
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := delete.NewDeleteCmd(f)
+	_, err := test.Execute(cmd, "my-comp rule-1 --confirm", out)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"taskID":77}`, strings.TrimSpace(out.String()))
+	r.Verify(t)
+}
+
+func TestDeleteRule_WaitsForPublished(t *testing.T) {
+	// Verifies polling continues through successive notPublished states.
+	r := &httpmock.Registry{}
+	r.Register(httpmock.REST("DELETE", "1/compositions/my-comp/rules/rule-1"), httpmock.StringResponse(`{"taskID":88}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/88"), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/88"), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/88"), httpmock.StringResponse(`{"status":"published"}`))
+
+	compinternal.PollInterval = 1 * time.Millisecond
+	compinternal.Timeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		compinternal.PollInterval = compinternal.DefaultPollInterval
+		compinternal.Timeout = compinternal.DefaultTimeout
+	})
+
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := delete.NewDeleteCmd(f)
+	_, err := test.Execute(cmd, "my-comp rule-1 --confirm", out)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"taskID":88}`, strings.TrimSpace(out.String()))
+	r.Verify(t)
+
+	taskPolls := 0
+	for _, req := range r.Requests {
+		if strings.Contains(req.URL.Path, "/task/") {
+			taskPolls++
+		}
+	}
+	assert.Equal(t, 3, taskPolls, "expected 3 task status polls (2x notPublished + 1x published)")
+}
+
+func TestDeleteRule_RequiresConfirmation(t *testing.T) {
+	// Without --confirm on a non-TTY, the prompt must fail and no HTTP request must be made.
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := delete.NewDeleteCmd(f)
+	_, err := test.Execute(cmd, "my-comp rule-1", out)
+	require.Error(t, err)
+	assert.Empty(t, out.String())
+	assert.Empty(t, r.Requests)
+}
+
+func TestDeleteRule_MissingArgs(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := delete.NewDeleteCmd(f)
+	_, err := test.Execute(cmd, "my-comp", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a <composition-id> and a <rule-id> argument")
+}

--- a/pkg/cmd/compositions/rules/get/get.go
+++ b/pkg/cmd/compositions/rules/get/get.go
@@ -1,0 +1,77 @@
+package get
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// GetOptions holds dependencies and flags for the rules get command.
+type GetOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	CompositionID     string
+	ObjectID          string
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewGetCmd returns the `compositions rules get` command.
+func NewGetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &GetOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get <composition-id> <rule-id>",
+		Short: "Get a composition rule by ID",
+		Args:  validators.ExactArgsWithMsg(2, "compositions rules get requires a <composition-id> and a <rule-id> argument."),
+		Annotations: map[string]string{
+			"acls": "search",
+		},
+		Example: heredoc.Doc(`
+			# Get rule "rule-1" for composition "my-comp"
+			$ algolia compositions rules get my-comp rule-1
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.CompositionID = args[0]
+			opts.ObjectID = args[1]
+			return runGetCmd(opts)
+		},
+	}
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runGetCmd(opts *GetOptions) error {
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Fetching rule")
+
+	res, err := client.GetRule(client.NewApiGetRuleRequest(opts.CompositionID, opts.ObjectID))
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/rules/get/get_test.go
+++ b/pkg/cmd/compositions/rules/get/get_test.go
@@ -1,0 +1,56 @@
+package get_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/cmd/compositions/rules/get"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+func TestGetRule(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		mock    string
+		wantOut string
+	}{
+		{
+			name:    "rule with injection consequence",
+			cli:     "my-comp rule-1",
+			mock:    `{"objectID":"rule-1","conditions":[{"anchoring":"is","pattern":"shirt"}],"consequence":{"behavior":{"injection":{"main":{}}}}}`,
+			wantOut: `{"conditions":[{"anchoring":"is","pattern":"shirt"}],"consequence":{"behavior":{"injection":{"main":{}}}},"objectID":"rule-1"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &httpmock.Registry{}
+			r.Register(
+				httpmock.REST("GET", "1/compositions/my-comp/rules/rule-1"),
+				httpmock.StringResponse(tt.mock),
+			)
+
+			f, out := test.NewFactory(false, r, nil, "")
+			cmd := get.NewGetCmd(f)
+			_, err := test.Execute(cmd, tt.cli, out)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, tt.wantOut, strings.TrimSpace(out.String()))
+			r.Verify(t)
+		})
+	}
+}
+
+func TestGetRule_MissingArgs(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := get.NewGetCmd(f)
+	_, err := test.Execute(cmd, "my-comp", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a <composition-id> and a <rule-id> argument")
+}

--- a/pkg/cmd/compositions/rules/list/list.go
+++ b/pkg/cmd/compositions/rules/list/list.go
@@ -1,0 +1,75 @@
+package list
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// ListOptions holds dependencies and flags for the rules list command.
+type ListOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	CompositionID     string
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewListCmd returns the `compositions rules list` command.
+func NewListCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &ListOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list <composition-id>",
+		Short: "List rules for a composition",
+		Args:  validators.ExactArgsWithMsg(1, "compositions rules list requires a <composition-id> argument."),
+		Annotations: map[string]string{
+			"acls": "search",
+		},
+		Example: heredoc.Doc(`
+			# List rules for the composition "my-comp"
+			$ algolia compositions rules list my-comp
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.CompositionID = args[0]
+			return runListCmd(opts)
+		},
+	}
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runListCmd(opts *ListOptions) error {
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Fetching rules")
+
+	res, err := client.SearchCompositionRules(client.NewApiSearchCompositionRulesRequest(opts.CompositionID))
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/rules/list/list_test.go
+++ b/pkg/cmd/compositions/rules/list/list_test.go
@@ -1,0 +1,63 @@
+package list_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/cmd/compositions/rules/list"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+// ruleJSON is a valid composition rule with consequence.behavior.injection populated
+// (v4.38.0+ requires a valid oneOf value in CompositionBehavior).
+const ruleJSON = `{"objectID":"rule-1","conditions":[{"anchoring":"is","pattern":"shirt"}],"consequence":{"behavior":{"injection":{"main":{}}}}}`
+
+func TestListRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		mock    string
+		wantOut string
+	}{
+		{
+			name:    "single rule",
+			mock:    `{"hits":[` + ruleJSON + `],"nbHits":1,"page":0,"nbPages":1,"hitsPerPage":20}`,
+			wantOut: `{"hits":[{"conditions":[{"anchoring":"is","pattern":"shirt"}],"consequence":{"behavior":{"injection":{"main":{}}}},"objectID":"rule-1"}],"nbHits":1,"nbPages":1,"page":0}`,
+		},
+		{
+			name:    "empty list",
+			mock:    `{"hits":[],"nbHits":0,"page":0,"nbPages":0,"hitsPerPage":20}`,
+			wantOut: `{"hits":[],"nbHits":0,"nbPages":0,"page":0}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &httpmock.Registry{}
+			r.Register(
+				httpmock.REST("POST", "1/compositions/my-comp/rules/search"),
+				httpmock.StringResponse(tt.mock),
+			)
+
+			f, out := test.NewFactory(false, r, nil, "")
+			cmd := list.NewListCmd(f)
+			_, err := test.Execute(cmd, "my-comp", out)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, tt.wantOut, strings.TrimSpace(out.String()))
+			r.Verify(t)
+		})
+	}
+}
+
+func TestListRules_MissingArg(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := list.NewListCmd(f)
+	_, err := test.Execute(cmd, "", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a <composition-id> argument")
+}

--- a/pkg/cmd/compositions/rules/rules.go
+++ b/pkg/cmd/compositions/rules/rules.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmd/compositions/rules/delete"
+	"github.com/algolia/cli/pkg/cmd/compositions/rules/get"
+	"github.com/algolia/cli/pkg/cmd/compositions/rules/list"
+	"github.com/algolia/cli/pkg/cmd/compositions/rules/upsert"
+	"github.com/algolia/cli/pkg/cmdutil"
+)
+
+// NewRulesCmd returns the compositions rules sub-group.
+func NewRulesCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rules",
+		Short: "Manage composition rules",
+		Long:  "List, get, upsert, and delete rules for an Algolia Composition.",
+	}
+
+	cmd.AddCommand(list.NewListCmd(f))
+	cmd.AddCommand(get.NewGetCmd(f))
+	cmd.AddCommand(upsert.NewUpsertCmd(f))
+	cmd.AddCommand(delete.NewDeleteCmd(f))
+	return cmd
+}

--- a/pkg/cmd/compositions/rules/upsert/upsert.go
+++ b/pkg/cmd/compositions/rules/upsert/upsert.go
@@ -98,5 +98,10 @@ func runUpsertCmd(opts *UpsertOptions) error {
 		return err
 	}
 
+	if opts.IO.IsStdoutTTY() {
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(opts.IO.Out, "%s Upserted rule %s in composition %s\n", cs.SuccessIcon(), opts.ObjectID, opts.CompositionID)
+	}
+
 	return p.Print(opts.IO, res)
 }

--- a/pkg/cmd/compositions/rules/upsert/upsert.go
+++ b/pkg/cmd/compositions/rules/upsert/upsert.go
@@ -1,0 +1,102 @@
+package upsert
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// UpsertOptions holds dependencies and flags for the rules upsert command.
+type UpsertOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	CompositionID     string
+	ObjectID          string
+	File              string
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewUpsertCmd returns the `compositions rules upsert` command.
+func NewUpsertCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &UpsertOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "upsert <composition-id> <rule-id>",
+		Short: "Create or update a composition rule",
+		Args:  validators.ExactArgsWithMsg(2, "compositions rules upsert requires a <composition-id> and a <rule-id> argument."),
+		Annotations: map[string]string{
+			"acls": "editSettings",
+		},
+		Example: heredoc.Doc(`
+			# Upsert a rule from a JSON file
+			$ algolia compositions rules upsert my-comp rule-1 --file rule.json
+
+			# Upsert from stdin
+			$ cat rule.json | algolia compositions rules upsert my-comp rule-1 --file -
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.CompositionID = args[0]
+			opts.ObjectID = args[1]
+			return runUpsertCmd(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "JSON file path (use - for stdin)")
+	_ = cmd.MarkFlagRequired("file")
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runUpsertCmd(opts *UpsertOptions) error {
+	raw, err := cmdutil.ReadFile(opts.File, opts.IO.In)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	var rule algoliaComposition.CompositionRule
+	if err := json.Unmarshal(raw, &rule); err != nil {
+		return fmt.Errorf("parsing rule JSON: %w", err)
+	}
+
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Upserting rule")
+
+	res, err := client.PutCompositionRule(client.NewApiPutCompositionRuleRequest(opts.CompositionID, opts.ObjectID, &rule))
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	if err := compinternal.WaitForTask(opts.IO, client, opts.CompositionID, res.TaskID, compinternal.PollInterval, compinternal.Timeout); err != nil {
+		return err
+	}
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/rules/upsert/upsert_test.go
+++ b/pkg/cmd/compositions/rules/upsert/upsert_test.go
@@ -1,0 +1,102 @@
+package upsert_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/cmd/compositions/rules/upsert"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+// validRuleBody is a well-formed rule body.
+// consequence.behavior must include injection or multifeed - SDK MarshalJSON panics on empty CompositionBehavior.
+const validRuleBody = `{"objectID":"rule-1","conditions":[{"anchoring":"is","pattern":"shirt"}],"consequence":{"behavior":{"injection":{"promote":[{"objectIDs":["obj1"],"position":0}]}}}}`
+
+func TestUpsertRule(t *testing.T) {
+	r := &httpmock.Registry{}
+	r.Register(httpmock.REST("PUT", "1/compositions/my-comp/rules/rule-1"), httpmock.StringResponse(`{"taskID":55}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/55"), httpmock.StringResponse(`{"status":"published"}`))
+
+	compinternal.PollInterval = 1 * time.Millisecond
+	compinternal.Timeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		compinternal.PollInterval = compinternal.DefaultPollInterval
+		compinternal.Timeout = compinternal.DefaultTimeout
+	})
+
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	out.InBuf.WriteString(validRuleBody)
+	_, err := test.Execute(cmd, "my-comp rule-1 --file -", out)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"taskID":55}`, strings.TrimSpace(out.String()))
+	r.Verify(t)
+}
+
+func TestUpsertRule_WaitsForPublished(t *testing.T) {
+	// Verifies polling continues through successive notPublished states.
+	r := &httpmock.Registry{}
+	r.Register(httpmock.REST("PUT", "1/compositions/my-comp/rules/rule-1"), httpmock.StringResponse(`{"taskID":66}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/66"), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/66"), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/66"), httpmock.StringResponse(`{"status":"published"}`))
+
+	compinternal.PollInterval = 1 * time.Millisecond
+	compinternal.Timeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		compinternal.PollInterval = compinternal.DefaultPollInterval
+		compinternal.Timeout = compinternal.DefaultTimeout
+	})
+
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	out.InBuf.WriteString(validRuleBody)
+	_, err := test.Execute(cmd, "my-comp rule-1 --file -", out)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"taskID":66}`, strings.TrimSpace(out.String()))
+	r.Verify(t)
+
+	taskPolls := 0
+	for _, req := range r.Requests {
+		if strings.Contains(req.URL.Path, "/task/") {
+			taskPolls++
+		}
+	}
+	assert.Equal(t, 3, taskPolls, "expected 3 task status polls (2x notPublished + 1x published)")
+}
+
+func TestUpsertRule_MissingFile(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	_, err := test.Execute(cmd, "my-comp rule-1", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file")
+}
+
+func TestUpsertRule_InvalidJSON(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	out.InBuf.WriteString(`not-json`)
+	_, err := test.Execute(cmd, "my-comp rule-1 --file -", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing rule JSON")
+}
+
+func TestUpsertRule_MissingArgs(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	_, err := test.Execute(cmd, "--file -", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a <composition-id> and a <rule-id> argument")
+}

--- a/pkg/cmd/compositions/search/search.go
+++ b/pkg/cmd/compositions/search/search.go
@@ -1,0 +1,116 @@
+package search
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// SearchOptions holds the dependencies and flags for the search command.
+type SearchOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	CompositionID     string
+	Query             string
+	HitsPerPage       *int32
+	Page              *int32
+	Filters           string
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewSearchCmd returns the `compositions search` command.
+func NewSearchCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &SearchOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	var hitsPerPage int32
+	var page int32
+
+	cmd := &cobra.Command{
+		Use:   "search <composition-id> <query>",
+		Short: "Search a composition",
+		Args:  validators.ExactArgsWithMsg(2, "compositions search requires a <composition-id> and a <query> argument."),
+		Annotations: map[string]string{
+			"acls": "search",
+		},
+		Example: heredoc.Doc(`
+			# Search a composition with a query
+			$ algolia compositions search my-comp "running shoes"
+
+			# Search with filters
+			$ algolia compositions search my-comp "shirt" --filters "brand:Nike"
+
+			# Search with pagination
+			$ algolia compositions search my-comp "shirt" --hits-per-page 20 --page 2
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.CompositionID = args[0]
+			opts.Query = args[1]
+			if cmd.Flags().Changed("hits-per-page") {
+				opts.HitsPerPage = &hitsPerPage
+			}
+			if cmd.Flags().Changed("page") {
+				opts.Page = &page
+			}
+			return runSearchCmd(opts)
+		},
+	}
+
+	cmd.Flags().Int32Var(&hitsPerPage, "hits-per-page", 20, "Number of hits per page")
+	cmd.Flags().Int32Var(&page, "page", 0, "Page number")
+	cmd.Flags().StringVar(&opts.Filters, "filters", "", "Filter expression")
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runSearchCmd(opts *SearchOptions) error {
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	params := algoliaComposition.NewParams(
+		algoliaComposition.WithParamsQuery(opts.Query),
+	)
+	if opts.HitsPerPage != nil {
+		params.HitsPerPage = opts.HitsPerPage
+	}
+	if opts.Page != nil {
+		params.Page = opts.Page
+	}
+	if opts.Filters != "" {
+		params.Filters = &opts.Filters
+	}
+
+	reqBody := algoliaComposition.NewRequestBody(
+		algoliaComposition.WithRequestBodyParams(*params),
+	)
+
+	opts.IO.StartProgressIndicatorWithLabel("Searching")
+
+	res, err := client.Search(client.NewApiSearchRequest(opts.CompositionID, reqBody))
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/search/search_test.go
+++ b/pkg/cmd/compositions/search/search_test.go
@@ -1,0 +1,62 @@
+package search_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compsearch "github.com/algolia/cli/pkg/cmd/compositions/search"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+func TestSearchComposition(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		mock    string
+		wantOut string
+	}{
+		{
+			name:    "basic query returns hits",
+			cli:     "my-comp shirt",
+			mock:    `{"hits":[{"objectID":"obj1","name":"shirt"}],"nbHits":1,"page":0,"hitsPerPage":20,"processingTimeMS":5}`,
+			wantOut: `{"hits":[{"name":"shirt","objectID":"obj1"}],"hitsPerPage":20,"nbHits":1,"page":0,"processingTimeMS":5,"results":null}`,
+		},
+		{
+			name:    "no results",
+			cli:     "my-comp nomatch",
+			mock:    `{"hits":[],"nbHits":0}`,
+			wantOut: `{"hits":[],"nbHits":0,"results":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &httpmock.Registry{}
+			r.Register(
+				httpmock.REST("POST", "1/compositions/my-comp/run"),
+				httpmock.StringResponse(tt.mock),
+			)
+
+			f, out := test.NewFactory(false, r, nil, "")
+			cmd := compsearch.NewSearchCmd(f)
+			_, err := test.Execute(cmd, tt.cli, out)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, tt.wantOut, strings.TrimSpace(out.String()))
+			r.Verify(t)
+		})
+	}
+}
+
+func TestSearchComposition_MissingArgs(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := compsearch.NewSearchCmd(f)
+	_, err := test.Execute(cmd, "my-comp", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a <composition-id> and a <query> argument")
+}

--- a/pkg/cmd/compositions/upsert/upsert.go
+++ b/pkg/cmd/compositions/upsert/upsert.go
@@ -1,0 +1,100 @@
+package upsert
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	algoliaComposition "github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
+	"github.com/spf13/cobra"
+
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// UpsertOptions holds dependencies and flags for the upsert command.
+type UpsertOptions struct {
+	Config            config.IConfig
+	IO                *iostreams.IOStreams
+	CompositionClient func() (*algoliaComposition.APIClient, error)
+	CompositionID     string
+	File              string
+	PrintFlags        *cmdutil.PrintFlags
+}
+
+// NewUpsertCmd returns the `compositions upsert` command.
+func NewUpsertCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &UpsertOptions{
+		IO:                f.IOStreams,
+		Config:            f.Config,
+		CompositionClient: f.CompositionClient,
+		PrintFlags:        cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "upsert <composition-id>",
+		Short: "Create or update a composition",
+		Args:  validators.ExactArgsWithMsg(1, "compositions upsert requires a <composition-id> argument."),
+		Annotations: map[string]string{
+			"acls": "editSettings",
+		},
+		Example: heredoc.Doc(`
+			# Upsert a composition from a JSON file
+			$ algolia compositions upsert my-comp --file body.json
+
+			# Upsert from stdin
+			$ cat body.json | algolia compositions upsert my-comp --file -
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.CompositionID = args[0]
+			return runUpsertCmd(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "JSON file path (use - for stdin)")
+	_ = cmd.MarkFlagRequired("file")
+
+	opts.PrintFlags.AddFlags(cmd)
+	return cmd
+}
+
+func runUpsertCmd(opts *UpsertOptions) error {
+	raw, err := cmdutil.ReadFile(opts.File, opts.IO.In)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	var comp algoliaComposition.Composition
+	if err := json.Unmarshal(raw, &comp); err != nil {
+		return fmt.Errorf("parsing composition JSON: %w", err)
+	}
+
+	client, err := opts.CompositionClient()
+	if err != nil {
+		return err
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Upserting composition")
+
+	res, err := client.PutComposition(client.NewApiPutCompositionRequest(opts.CompositionID, &comp))
+	if err != nil {
+		opts.IO.StopProgressIndicator()
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	if err := compinternal.WaitForTask(opts.IO, client, opts.CompositionID, res.TaskID, compinternal.PollInterval, compinternal.Timeout); err != nil {
+		return err
+	}
+
+	return p.Print(opts.IO, res)
+}

--- a/pkg/cmd/compositions/upsert/upsert.go
+++ b/pkg/cmd/compositions/upsert/upsert.go
@@ -96,5 +96,10 @@ func runUpsertCmd(opts *UpsertOptions) error {
 		return err
 	}
 
+	if opts.IO.IsStdoutTTY() {
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(opts.IO.Out, "%s Upserted composition %s\n", cs.SuccessIcon(), opts.CompositionID)
+	}
+
 	return p.Print(opts.IO, res)
 }

--- a/pkg/cmd/compositions/upsert/upsert_test.go
+++ b/pkg/cmd/compositions/upsert/upsert_test.go
@@ -1,0 +1,101 @@
+package upsert_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compinternal "github.com/algolia/cli/pkg/cmd/compositions/internal"
+	"github.com/algolia/cli/pkg/cmd/compositions/upsert"
+	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/test"
+)
+
+// validCompBody is a well-formed composition body using the injection behavior schema.
+const validCompBody = `{"objectID":"my-comp","behavior":{"injection":{"indices":[{"indexName":"products","maxRecommendations":5}]}}}`
+
+func TestUpsertComposition(t *testing.T) {
+	r := &httpmock.Registry{}
+	r.Register(httpmock.REST("PUT", "1/compositions/my-comp"), httpmock.StringResponse(`{"taskID":42}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/42"), httpmock.StringResponse(`{"status":"published"}`))
+
+	compinternal.PollInterval = 1 * time.Millisecond
+	compinternal.Timeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		compinternal.PollInterval = compinternal.DefaultPollInterval
+		compinternal.Timeout = compinternal.DefaultTimeout
+	})
+
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	out.InBuf.WriteString(validCompBody)
+	_, err := test.Execute(cmd, "my-comp --file -", out)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"taskID":42}`, strings.TrimSpace(out.String()))
+	r.Verify(t)
+}
+
+func TestUpsertComposition_WaitsForPublished(t *testing.T) {
+	// Verifies that the command polls until published before printing.
+	r := &httpmock.Registry{}
+	r.Register(httpmock.REST("PUT", "1/compositions/my-comp"), httpmock.StringResponse(`{"taskID":99}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/99"), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/99"), httpmock.StringResponse(`{"status":"notPublished"}`))
+	r.Register(httpmock.REST("GET", "1/compositions/my-comp/task/99"), httpmock.StringResponse(`{"status":"published"}`))
+
+	compinternal.PollInterval = 1 * time.Millisecond
+	compinternal.Timeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		compinternal.PollInterval = compinternal.DefaultPollInterval
+		compinternal.Timeout = compinternal.DefaultTimeout
+	})
+
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	out.InBuf.WriteString(validCompBody)
+	_, err := test.Execute(cmd, "my-comp --file -", out)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"taskID":99}`, strings.TrimSpace(out.String()))
+	r.Verify(t)
+
+	taskPolls := 0
+	for _, req := range r.Requests {
+		if strings.Contains(req.URL.Path, "/task/") {
+			taskPolls++
+		}
+	}
+	assert.Equal(t, 3, taskPolls, "expected 3 task status polls (2x notPublished + 1x published)")
+}
+
+func TestUpsertComposition_MissingFile(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	_, err := test.Execute(cmd, "my-comp", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file")
+}
+
+func TestUpsertComposition_InvalidJSON(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	out.InBuf.WriteString(`not-json`)
+	_, err := test.Execute(cmd, "my-comp --file -", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing composition JSON")
+}
+
+func TestUpsertComposition_MissingArg(t *testing.T) {
+	r := &httpmock.Registry{}
+	f, out := test.NewFactory(false, r, nil, "")
+	cmd := upsert.NewUpsertCmd(f)
+	_, err := test.Execute(cmd, "--file -", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a <composition-id> argument")
+}

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/search"
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/transport"
 
@@ -23,6 +24,7 @@ func New(appVersion string, cfg config.IConfig) *cmdutil.Factory {
 	f.IOStreams = ioStreams(f)
 	f.SearchClient = searchClient(f, appVersion)
 	f.CrawlerClient = crawlerClient(f)
+	f.CompositionClient = compositionClient(f, appVersion)
 
 	return f
 }
@@ -82,6 +84,35 @@ func crawlerClient(f *cmdutil.Factory) func() (*crawler.Client, error) {
 		}
 
 		return crawler.NewClient(userID, APIKey), nil
+	}
+}
+
+func compositionClient(f *cmdutil.Factory, appVersion string) func() (*composition.APIClient, error) {
+	return func() (*composition.APIClient, error) {
+		appID, err := f.Config.Profile().GetApplicationID()
+		if err != nil {
+			return nil, err
+		}
+		apiKey, err := f.Config.Profile().GetAPIKey()
+		if err != nil {
+			return nil, err
+		}
+
+		userAgent, err := getUserAgentInfo(appID, apiKey, appVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		clientConf := composition.CompositionConfiguration{
+			Configuration: transport.Configuration{
+				AppID:                           appID,
+				ApiKey:                          apiKey,
+				UserAgent:                       userAgent,
+				ExposeIntermediateNetworkErrors: true,
+			},
+		}
+
+		return composition.NewClientWithConfig(clientConf)
 	}
 }
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/algolia/cli/pkg/cmd/apikeys"
 	"github.com/algolia/cli/pkg/cmd/application"
 	authcmd "github.com/algolia/cli/pkg/cmd/auth"
+	"github.com/algolia/cli/pkg/cmd/compositions"
 	"github.com/algolia/cli/pkg/cmd/crawler"
 	"github.com/algolia/cli/pkg/cmd/describe"
 	"github.com/algolia/cli/pkg/cmd/dictionary"
@@ -115,6 +116,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(dictionary.NewDictionaryCmd(f))
 	cmd.AddCommand(events.NewEventsCmd(f))
 	cmd.AddCommand(crawler.NewCrawlersCmd(f))
+	cmd.AddCommand(compositions.NewCompositionsCmd(f))
 
 	return cmd
 }

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/search"
 
 	"github.com/algolia/cli/api/crawler"
@@ -13,10 +14,11 @@ import (
 )
 
 type Factory struct {
-	IOStreams     *iostreams.IOStreams
-	Config        config.IConfig
-	SearchClient  func() (*search.APIClient, error)
-	CrawlerClient func() (*crawler.Client, error)
+	IOStreams         *iostreams.IOStreams
+	Config            config.IConfig
+	SearchClient      func() (*search.APIClient, error)
+	CrawlerClient     func() (*crawler.Client, error)
+	CompositionClient func() (*composition.APIClient, error)
 
 	ExecutableName string
 }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
 
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/composition"
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/search"
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/transport"
 	"github.com/algolia/cli/api/crawler"
@@ -84,6 +85,16 @@ func NewFactory(
 			return crawler.NewClientWithHTTPClient("id", "key", &http.Client{
 				Transport: r,
 			}), nil
+		}
+		f.CompositionClient = func() (*composition.APIClient, error) {
+			cfg := composition.CompositionConfiguration{
+				Configuration: transport.Configuration{
+					AppID:     "default",
+					ApiKey:    "default",
+					Requester: r,
+				},
+			}
+			return composition.NewClientWithConfig(cfg)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds a new compositions command group to the Algolia CLI covering the full management lifecycle for Algolia Compositions (https://www.algolia.com/doc/rest-api/composition/).

- This also bumps the Algolia Go SDK from v4.35.0 to v4.38.0 to pick up the composition package.

## Commands added

### Composition management:

```
algolia compositions list
algolia compositions get <composition-id>
algolia compositions upsert <composition-id> --file body.json
algolia compositions delete <composition-id>
algolia compositions search <composition-id> <query>
```

### Composition rule management:

```
algolia compositions rules list <composition-id>
algolia compositions rules get <composition-id> <rule-id>
algolia compositions rules upsert <composition-id> <rule-id> --file rule.json
algolia compositions rules delete <composition-id> <rule-id>
```

### Design notes

- All write operations (upsert, delete) always wait for the task to reach published status before returning. There is no --wait flag unlike `indices` command group.
- Delete commands prompt for confirmation unless --confirm/-y is passed.
- ACLs are enforced: read commands require search, write commands require editSettings.


## Changes

- `go.mod / go.sum`: Bump algoliasearch-client-go/v4 to v4.38.0
- `pkg/cmdutil/factory.go`: Add CompositionClient field
- `pkg/cmd/factory/default.go`: Implement compositionClient() factory function
- `pkg/cmd/root/root.go`: Register NewCompositionsCmd
- `pkg/cmd/compositions/`: New command group

## Tests

Each command has a unit test file covering:
- Happy path with exact JSON output assertion
- Missing required argument(s) - verifies descriptive error message
- For upsert commands: missing --file flag, invalid JSON input
- For delete commands: confirmation required

End to end test script:
e2e/testscripts/compositions/compositions.txtar
