### PR TITLE
fix(oauth): inject public OAuth defaults

### DIFF
--- a/api/dashboard/client.go
+++ b/api/dashboard/client.go
@@ -11,17 +11,11 @@ import (
 	"strings"
 )
 
-// DefaultDashboardURL and DefaultAPIURL are empty by default and must be
-// injected at build time via ldflags, e.g.:
-//
-//	go build -ldflags "-X github.com/algolia/cli/api/dashboard.DefaultDashboardURL=https://..."
-//
-// They can also be overridden at runtime with ALGOLIA_DASHBOARD_URL / ALGOLIA_API_URL / ALGOLIA_OAUTH_SCOPE
-// environment variables.
+// Production defaults; overridable via ldflags or ALGOLIA_DASHBOARD_URL / ALGOLIA_API_URL / ALGOLIA_OAUTH_SCOPE env vars.
 var (
-	DefaultDashboardURL = ""
-	DefaultAPIURL       = ""
-	DefaultOAuthScope   = ""
+	DefaultDashboardURL = "https://dashboard.algolia.com"
+	DefaultAPIURL       = "https://api.dashboard.algolia.com"
+	DefaultOAuthScope   = "public applications:manage keys:manage"
 )
 
 // Client interacts with the Algolia Dashboard OAuth endpoint and the Public API.

--- a/pkg/auth/oauth_flow.go
+++ b/pkg/auth/oauth_flow.go
@@ -10,9 +10,8 @@ import (
 	"github.com/algolia/cli/pkg/iostreams"
 )
 
-// DefaultOAuthClientID is injected at build time via ldflags.
-// Override with ALGOLIA_OAUTH_CLIENT_ID environment variable for local development.
-var DefaultOAuthClientID = ""
+// DefaultOAuthClientID is a public OAuth client ID (PKCE flow, not a secret).
+var DefaultOAuthClientID = "-6xbCNF7usNqkcacFHKt0WHCJIZ2rlp2bP2_VH12xQE"
 
 // OAuthClientID returns the OAuth client ID, preferring the ALGOLIA_OAUTH_CLIENT_ID
 // environment variable over the compiled-in default (set via ldflags).


### PR DESCRIPTION
Since they are public values anyway, and `brew install algolia` needs them, might as well inject them

[GROUT-234]

[GROUT-234]: https://algolia.atlassian.net/browse/GROUT-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ