### PR TITLE
feat(agentstudio): PR-01 — HTTP client foundation + Factory wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
-# Local
+# Local / build defaults (passed through `task build` via -X ldflags — see AGENTS.md)
 ALGOLIA_DASHBOARD_URL=
 ALGOLIA_API_URL=
 ALGOLIA_SEARCH_HOSTS=
 ALGOLIA_OAUTH_CLIENT_ID=
 ALGOLIA_OAUTH_SCOPE=
+# Agent Studio backing host (staging EU default for internal tooling; omit for prod cluster-proxy resolution)
+ALGOLIA_AGENT_STUDIO_URL=

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,7 +20,8 @@ tasks:
       -X github.com/algolia/cli/api/dashboard.DefaultAPIURL=$ALGOLIA_API_URL
       -X github.com/algolia/cli/pkg/config.DefaultSearchHosts=$ALGOLIA_SEARCH_HOSTS
       -X github.com/algolia/cli/pkg/auth.DefaultOAuthClientID=$ALGOLIA_OAUTH_CLIENT_ID
-      -X 'github.com/algolia/cli/api/dashboard.DefaultOAuthScope=$ALGOLIA_OAUTH_SCOPE'"
+      -X 'github.com/algolia/cli/api/dashboard.DefaultOAuthScope=$ALGOLIA_OAUTH_SCOPE'
+      -X github.com/algolia/cli/api/agentstudio.DefaultBaseURL=$ALGOLIA_AGENT_STUDIO_URL"
       -o algolia cmd/algolia/main.go
     vars:
       VERSION: '{{ .VERSION | default "main" }}'

--- a/api/agentstudio/agents.go
+++ b/api/agentstudio/agents.go
@@ -1,0 +1,217 @@
+package agentstudio
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ListAgents calls GET /1/agents.
+func (c *Client) ListAgents(ctx context.Context, params ListAgentsParams) (*PaginatedAgentsResponse, error) {
+	q := url.Values{}
+	if params.Page > 0 {
+		q.Set("page", strconv.Itoa(params.Page))
+	}
+	if params.Limit > 0 {
+		q.Set("limit", strconv.Itoa(params.Limit))
+	}
+	if params.ProviderID != "" {
+		q.Set("providerId", params.ProviderID)
+	}
+
+	endpoint := c.cfg.BaseURL + "/1/agents"
+	if encoded := q.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("agent studio: list agents: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var out PaginatedAgentsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("agent studio: decode list agents response: %w", err)
+	}
+	return &out, nil
+}
+
+// GetAgent calls GET /1/agents/{id}.
+func (c *Client) GetAgent(ctx context.Context, id string) (*Agent, error) {
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("agent studio: agent id is required")
+	}
+
+	endpoint := c.cfg.BaseURL + "/1/agents/" + url.PathEscape(id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("agent studio: get agent: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var out Agent
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("agent studio: decode get agent response: %w", err)
+	}
+	return &out, nil
+}
+
+// CreateAgent calls POST /1/agents. Body is opaque JSON; see docs/agents.md.
+func (c *Client) CreateAgent(ctx context.Context, body json.RawMessage) (*Agent, error) {
+	if len(body) == 0 {
+		return nil, fmt.Errorf("agent studio: create agent: body is required")
+	}
+	return c.doAgentMutation(ctx, http.MethodPost, c.cfg.BaseURL+"/1/agents", body, "create agent")
+}
+
+// UpdateAgent calls PATCH /1/agents/{id}.
+func (c *Client) UpdateAgent(ctx context.Context, id string, body json.RawMessage) (*Agent, error) {
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("agent studio: agent id is required")
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("agent studio: update agent: body is required")
+	}
+	endpoint := c.cfg.BaseURL + "/1/agents/" + url.PathEscape(id)
+	return c.doAgentMutation(ctx, http.MethodPatch, endpoint, body, "update agent")
+}
+
+// DeleteAgent calls DELETE /1/agents/{id}. Backend soft-deletes;
+// recovery is a backend ops concern.
+func (c *Client) DeleteAgent(ctx context.Context, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return fmt.Errorf("agent studio: agent id is required")
+	}
+	endpoint := c.cfg.BaseURL + "/1/agents/" + url.PathEscape(id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("agent studio: delete agent: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return checkResponse(resp)
+}
+
+// PublishAgent calls POST /1/agents/{id}/publish.
+func (c *Client) PublishAgent(ctx context.Context, id string) (*Agent, error) {
+	return c.doAgentLifecycle(ctx, id, "publish")
+}
+
+// UnpublishAgent calls POST /1/agents/{id}/unpublish.
+func (c *Client) UnpublishAgent(ctx context.Context, id string) (*Agent, error) {
+	return c.doAgentLifecycle(ctx, id, "unpublish")
+}
+
+// DuplicateAgent calls POST /1/agents/{id}/duplicate.
+func (c *Client) DuplicateAgent(ctx context.Context, id string) (*Agent, error) {
+	return c.doAgentLifecycle(ctx, id, "duplicate")
+}
+
+// InvalidateAgentCache calls DELETE /1/agents/{id}/cache?before=YYYY-MM-DD.
+// Empty before = wipe all cache entries. Date format is validated
+// server-side (see docs/agents.md gotchas).
+func (c *Client) InvalidateAgentCache(ctx context.Context, id, before string) error {
+	if strings.TrimSpace(id) == "" {
+		return fmt.Errorf("agent studio: agent id is required")
+	}
+
+	endpoint := c.cfg.BaseURL + "/1/agents/" + url.PathEscape(id) + "/cache"
+	if before != "" {
+		q := url.Values{}
+		q.Set("before", before)
+		endpoint += "?" + q.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("agent studio: invalidate agent cache: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return checkResponse(resp)
+}
+
+func (c *Client) doAgentLifecycle(ctx context.Context, id, verb string) (*Agent, error) {
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("agent studio: agent id is required")
+	}
+	endpoint := c.cfg.BaseURL + "/1/agents/" + url.PathEscape(id) + "/" + verb
+	return c.doAgentMutation(ctx, http.MethodPost, endpoint, nil, verb+" agent")
+}
+
+func (c *Client) doAgentMutation(
+	ctx context.Context,
+	method, endpoint string,
+	body json.RawMessage,
+	errLabel string,
+) (*Agent, error) {
+	var reqBody io.Reader
+	if body != nil {
+		reqBody = strings.NewReader(string(body))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	c.setHeaders(req)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("agent studio: %s: %w", errLabel, err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var out Agent
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("agent studio: decode %s response: %w", errLabel, err)
+	}
+	return &out, nil
+}

--- a/api/agentstudio/client.go
+++ b/api/agentstudio/client.go
@@ -1,0 +1,166 @@
+package agentstudio
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	HeaderApplicationID = "X-Algolia-Application-Id"
+	HeaderAPIKey        = "X-Algolia-API-Key" //nolint:gosec // header name, not a credential
+	HeaderUserID        = "X-Algolia-User-ID"
+)
+
+// Config configures a Client. ApplicationID, APIKey, and BaseURL are
+// required; everything else is optional.
+type Config struct {
+	BaseURL       string
+	ApplicationID string
+	APIKey        string
+	UserID        string
+	UserAgent     string
+	HTTPClient    *http.Client
+}
+
+// Client talks to the Agent Studio backend. Methods are organised by API
+// tag — one source file per tag (agents.go, completions.go, …). This
+// file carries only Config, NewClient, header injection, and error
+// mapping.
+type Client struct {
+	cfg        Config
+	httpClient *http.Client
+}
+
+// defaultHTTPClient returns a client suitable for both short JSON calls
+// and long-lived SSE streams: ResponseHeaderTimeout caps stalls before
+// the first byte; Client.Timeout stays zero so an open stream is not
+// cut off after a fixed wall clock.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			ResponseHeaderTimeout: 60 * time.Second,
+		},
+	}
+}
+
+// NewClient validates cfg and returns a ready-to-use Client.
+func NewClient(cfg Config) (*Client, error) {
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		return nil, fmt.Errorf("agent studio: base url is required")
+	}
+	if strings.TrimSpace(cfg.ApplicationID) == "" {
+		return nil, fmt.Errorf("agent studio: application id is required")
+	}
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, fmt.Errorf("agent studio: api key is required")
+	}
+
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = defaultHTTPClient()
+	}
+	if cfg.UserAgent == "" {
+		cfg.UserAgent = "algolia-cli/agentstudio"
+	}
+
+	return &Client{cfg: cfg, httpClient: cfg.HTTPClient}, nil
+}
+
+func (c *Client) setHeaders(req *http.Request) {
+	req.Header.Set(HeaderApplicationID, c.cfg.ApplicationID)
+	req.Header.Set(HeaderAPIKey, c.cfg.APIKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.cfg.UserAgent)
+	if c.cfg.UserID != "" {
+		req.Header.Set(HeaderUserID, c.cfg.UserID)
+	}
+}
+
+// checkResponse returns nil for 2xx and an *APIError otherwise.
+func checkResponse(resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+
+	return &APIError{
+		StatusCode: resp.StatusCode,
+		Body:       body,
+		Detail:     extractDetail(body),
+		Sentinel:   sentinelFor(resp.StatusCode, body),
+	}
+}
+
+// extractDetail pulls a human-readable message from the response body.
+// Priority: structured FastAPI detail[].msg > string detail > Algolia
+// {message:...} > raw body.
+func extractDetail(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	var generic map[string]any
+	if err := json.Unmarshal(body, &generic); err != nil {
+		s := strings.TrimSpace(string(body))
+		if len(s) > 512 {
+			return s[:512] + "…"
+		}
+		return s
+	}
+
+	switch d := generic["detail"].(type) {
+	case []any:
+		if len(d) > 0 {
+			if first, ok := d[0].(map[string]any); ok {
+				if msg, ok := first["msg"].(string); ok && msg != "" {
+					return msg
+				}
+			}
+		}
+	case string:
+		if d != "" {
+			return d
+		}
+	}
+
+	if msg, ok := generic["message"].(string); ok && msg != "" {
+		return msg
+	}
+
+	return ""
+}
+
+// sentinelFor maps a status code (and body markers) to a sentinel error.
+func sentinelFor(status int, body []byte) error {
+	switch {
+	case status == http.StatusUnauthorized:
+		return ErrUnauthorized
+	case status == http.StatusForbidden:
+		// Backend uses this exact phrase when the GenAI feature flag is off.
+		if strings.Contains(strings.ToLower(string(body)), "feature is not enabled") {
+			return ErrFeatureDisabled
+		}
+		return ErrForbidden
+	case status == http.StatusNotFound:
+		return ErrNotFound
+	case status >= 500:
+		return ErrServer
+	}
+	return nil
+}

--- a/api/agentstudio/client_test.go
+++ b/api/agentstudio/client_test.go
@@ -1,0 +1,218 @@
+package agentstudio
+
+// Tests for the cross-cutting infrastructure in client.go: NewClient
+// validation, header injection, error mapping (checkResponse +
+// extractDetail + sentinelFor), and context cancellation. Per-tag
+// method tests live in <tag>_test.go (agents_test.go,
+// completions_test.go, providers_test.go, configuration_test.go).
+//
+// The error-mapping and ctx-cancellation tests use ListAgents as a
+// vehicle: it's the simplest GET endpoint in the package and exercising
+// it keeps the assertions concrete. They are infra tests, not method
+// tests — moving them to agents_test.go would obscure their intent.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestJSONResponse writes fixture JSON to w without calling
+// http.ResponseWriter.Write directly. Static scanners flag that pattern as a
+// potential HTML XSS sink even for JSON test doubles.
+func writeTestJSONResponse(w http.ResponseWriter, body []byte) {
+	var out io.Writer = w
+	_, _ = out.Write(body)
+}
+
+// newTestClient is the shared httptest harness for every *_test.go in
+// this package. Lives here because client.go owns Client construction.
+func newTestClient(t *testing.T, handler http.Handler) (*httptest.Server, *Client) {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	c, err := NewClient(Config{
+		BaseURL:       ts.URL,
+		ApplicationID: "APP123",
+		APIKey:        "key-abc",
+		UserID:        "cli-test",
+		HTTPClient:    ts.Client(),
+	})
+	require.NoError(t, err)
+	return ts, c
+}
+
+func TestNewClient_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{"missing baseURL", Config{ApplicationID: "x", APIKey: "y"}, "base url is required"},
+		{"missing appID", Config{BaseURL: "http://x", APIKey: "y"}, "application id is required"},
+		{"missing apiKey", Config{BaseURL: "http://x", ApplicationID: "y"}, "api key is required"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewClient(tc.cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestNewClient_TrimsTrailingSlashAndDefaults(t *testing.T) {
+	c, err := NewClient(Config{
+		BaseURL:       "https://x.example.com/",
+		ApplicationID: "APP",
+		APIKey:        "k",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://x.example.com", c.cfg.BaseURL)
+	assert.Equal(t, "algolia-cli/agentstudio", c.cfg.UserAgent)
+	require.NotNil(t, c.httpClient)
+	assert.Zero(t, c.httpClient.Timeout)
+	_, ok := c.httpClient.Transport.(*http.Transport)
+	assert.True(t, ok, "expected default *http.Transport for timeouts without killing SSE streams")
+}
+
+func TestCheckResponse_ErrorMapping(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		body         string
+		wantSentinel error
+		wantDetail   string
+	}{
+		{
+			name:         "401 → ErrUnauthorized",
+			status:       http.StatusUnauthorized,
+			body:         `{"detail":"Invalid API key"}`,
+			wantSentinel: ErrUnauthorized,
+			wantDetail:   "Invalid API key",
+		},
+		{
+			name:         "403 missing ACL → ErrForbidden",
+			status:       http.StatusForbidden,
+			body:         `{"message":"API key is missing the following ACLs: settings."}`,
+			wantSentinel: ErrForbidden,
+			wantDetail:   "API key is missing the following ACLs: settings.",
+		},
+		{
+			name:         "403 feature disabled → ErrFeatureDisabled",
+			status:       http.StatusForbidden,
+			body:         `{"message":"This feature is not enabled for this application."}`,
+			wantSentinel: ErrFeatureDisabled,
+			wantDetail:   "This feature is not enabled for this application.",
+		},
+		{
+			name:         "404 → ErrNotFound",
+			status:       http.StatusNotFound,
+			body:         `{"detail":"Agent not found"}`,
+			wantSentinel: ErrNotFound,
+			wantDetail:   "Agent not found",
+		},
+		{
+			name:         "500 → ErrServer",
+			status:       http.StatusInternalServerError,
+			body:         `{"detail":"oops"}`,
+			wantSentinel: ErrServer,
+			wantDetail:   "oops",
+		},
+		{
+			name:         "422 (validation) wraps no sentinel but preserves detail",
+			status:       http.StatusUnprocessableEntity,
+			body:         `{"detail":[{"msg":"name is required"}]}`,
+			wantSentinel: nil,
+			wantDetail:   "name is required",
+		},
+		{
+			name:         "non-JSON body falls back to raw text",
+			status:       http.StatusBadGateway,
+			body:         `<html>upstream broke</html>`,
+			wantSentinel: ErrServer,
+			wantDetail:   "<html>upstream broke</html>",
+		},
+		{
+			// Regression for live behaviour: when the backend pairs a generic
+			// "Input is invalid, see detail/body:" message with a structured
+			// detail array, the structured msg wins.
+			name:   "422 with both message and detail prefers structured detail.msg",
+			status: http.StatusUnprocessableEntity,
+			body: `{
+				"message":"Input is invalid, see detail/body:",
+				"detail":[{"loc":["path","agent_id"],"msg":"Input should be a valid UUID","type":"uuid_parsing"}]
+			}`,
+			wantSentinel: nil,
+			wantDetail:   "Input should be a valid UUID",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/1/agents", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				writeTestJSONResponse(w, []byte(tc.body))
+			})
+			_, c := newTestClient(t, mux)
+
+			_, err := c.ListAgents(context.Background(), ListAgentsParams{})
+			require.Error(t, err)
+
+			var apiErr *APIError
+			require.True(t, errors.As(err, &apiErr), "expected *APIError, got %T", err)
+			assert.Equal(t, tc.status, apiErr.StatusCode)
+			assert.Equal(t, tc.wantDetail, apiErr.Detail)
+
+			if tc.wantSentinel != nil {
+				assert.True(t, errors.Is(err, tc.wantSentinel),
+					"expected errors.Is(err, %v); got %v", tc.wantSentinel, err)
+			}
+		})
+	}
+}
+
+func TestRequest_ContextCancellation(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/agents", func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+	_, c := newTestClient(t, mux)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.ListAgents(ctx, ListAgentsParams{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "got %v", err)
+}
+
+func TestSetHeaders_OmitsUserIDWhenEmpty(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/agents", func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get(HeaderUserID))
+		writeTestJSONResponse(w, []byte(`{"data":[],"pagination":{"page":1,"limit":10,"totalCount":0,"totalPages":0}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	c, err := NewClient(Config{
+		BaseURL:       ts.URL,
+		ApplicationID: "APP",
+		APIKey:        "k",
+		HTTPClient:    ts.Client(),
+		// no UserID
+	})
+	require.NoError(t, err)
+
+	_, err = c.ListAgents(context.Background(), ListAgentsParams{})
+	require.NoError(t, err)
+}

--- a/api/agentstudio/errors.go
+++ b/api/agentstudio/errors.go
@@ -1,0 +1,37 @@
+package agentstudio
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Sentinel errors callers can match with errors.Is.
+var (
+	ErrUnauthorized    = errors.New("agent studio: unauthorized — check your application id and api key")
+	ErrForbidden       = errors.New("agent studio: forbidden — the api key is missing a required ACL")
+	ErrFeatureDisabled = errors.New(
+		"agent studio: feature is not enabled for this application — contact your Algolia account team or enable it from the Dashboard",
+	)
+	ErrNotFound = errors.New("agent studio: resource not found")
+	ErrServer   = errors.New("agent studio: server error")
+)
+
+// APIError is the structured error returned for any non-2xx response.
+// Sentinel wraps one of the package-level sentinels (or nil for 4xx
+// not in the table above).
+type APIError struct {
+	StatusCode int
+	Detail     string
+	Body       []byte
+	Sentinel   error
+}
+
+func (e *APIError) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("agent studio: %d %s: %s", e.StatusCode, http.StatusText(e.StatusCode), e.Detail)
+	}
+	return fmt.Sprintf("agent studio: %d %s", e.StatusCode, http.StatusText(e.StatusCode))
+}
+
+func (e *APIError) Unwrap() error { return e.Sentinel }

--- a/api/agentstudio/host.go
+++ b/api/agentstudio/host.go
@@ -1,0 +1,148 @@
+// Package agentstudio is a thin Go client for Algolia's Agent Studio
+// API (github.com/algolia/conversational-ai). Auth is the standard
+// X-Algolia-Application-Id / X-Algolia-API-Key pair — same identity
+// stack as the Search API, no OAuth bearer tokens.
+package agentstudio
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// DefaultBaseURL is the build-time default for the Agent Studio base
+// URL, set via ldflags by `task build`. Empty in production builds
+// (cluster-proxy fallback applies); set to the EU staging host for
+// internal beta builds. Runtime overrides win.
+var DefaultBaseURL string
+
+// EnvAllowInsecureAgentStudioHTTP must be non-empty to permit http://
+// overrides (ALGOLIA_AGENT_STUDIO_URL / profile agent_studio_url). Use
+// only for local development; production overrides must be https://.
+const EnvAllowInsecureAgentStudioHTTP = "ALGOLIA_AGENT_STUDIO_ALLOW_INSECURE_HTTP"
+
+const (
+	EnvProd    = "prod"
+	EnvStaging = "staging"
+)
+
+const (
+	RegionEU = "eu"
+	RegionUS = "us"
+)
+
+// HostOptions controls how the Agent Studio base URL is resolved.
+// Precedence: Override > {Region}.algolia.com (per Env) > cluster-proxy
+// fallback via ApplicationID.
+type HostOptions struct {
+	Region        string
+	Env           string
+	ApplicationID string
+	Override      string
+}
+
+var (
+	// clusterProxyApplicationIDRx construes app IDs that are safe to
+	// embed as a single DNS label in https://<id>.algolia.net/agent-studio.
+	clusterProxyApplicationIDRx = regexp.MustCompile(`^[A-Za-z0-9]{4,32}$`)
+
+	ErrUnknownRegion      = errors.New("unknown agent studio region")
+	ErrStagingNotInRegion = errors.New("agent studio staging is only available in eu")
+	ErrNoHostResolvable   = errors.New(
+		"cannot resolve agent studio host: set --agent-studio-url, configure a region on the profile, or pass an application id",
+	)
+)
+
+// ResolveHost returns the Agent Studio base URL for the given options
+// (no trailing slash, no /1 suffix — callers append the path).
+func ResolveHost(opts HostOptions) (string, error) {
+	if opts.Override != "" {
+		return normalizeAgentStudioOverride(opts.Override)
+	}
+
+	env := strings.ToLower(strings.TrimSpace(opts.Env))
+	if env == "" {
+		env = EnvProd
+	}
+	if env != EnvProd && env != EnvStaging {
+		return "", fmt.Errorf("unknown agent studio env %q (expected %q or %q)", opts.Env, EnvProd, EnvStaging)
+	}
+
+	region := strings.ToLower(strings.TrimSpace(opts.Region))
+	switch region {
+	case RegionEU:
+		if env == EnvStaging {
+			return "https://agent-studio.staging.eu.algolia.com", nil
+		}
+		return "https://agent-studio.eu.algolia.com", nil
+	case RegionUS:
+		if env == EnvStaging {
+			return "", ErrStagingNotInRegion
+		}
+		return "https://agent-studio.us.algolia.com", nil
+	case "":
+		// Fall through to cluster-proxy fallback.
+	default:
+		return "", fmt.Errorf("%w: %q", ErrUnknownRegion, opts.Region)
+	}
+
+	// Cluster-proxy fallback: app's own cluster routes to the right region.
+	appID := strings.TrimSpace(opts.ApplicationID)
+	if appID != "" {
+		if err := validateClusterProxyApplicationID(appID); err != nil {
+			return "", err
+		}
+		return "https://" + appID + ".algolia.net/agent-studio", nil
+	}
+
+	return "", ErrNoHostResolvable
+}
+
+func normalizeAgentStudioOverride(raw string) (string, error) {
+	s := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if s == "" {
+		return "", fmt.Errorf("agent studio url override is empty")
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("agent studio url override: %w", err)
+	}
+	if u.Scheme == "" {
+		return "", fmt.Errorf(
+			"agent studio url override must include a scheme (e.g. https://)",
+		)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("agent studio url override must include a host")
+	}
+	switch u.Scheme {
+	case "https":
+		return s, nil
+	case "http":
+		if os.Getenv(EnvAllowInsecureAgentStudioHTTP) == "" {
+			return "", fmt.Errorf(
+				"agent studio url must use https:// (got http://); for local development set %s=1",
+				EnvAllowInsecureAgentStudioHTTP,
+			)
+		}
+		return s, nil
+	default:
+		return "", fmt.Errorf(
+			"agent studio url scheme %q is not supported (use https://)",
+			u.Scheme,
+		)
+	}
+}
+
+func validateClusterProxyApplicationID(appID string) error {
+	if !clusterProxyApplicationIDRx.MatchString(appID) {
+		return fmt.Errorf(
+			"invalid application id %q for agent studio cluster URL: expect 4-32 alphanumeric characters (A-Z, a-z, 0-9)",
+			appID,
+		)
+	}
+	return nil
+}

--- a/api/agentstudio/host_test.go
+++ b/api/agentstudio/host_test.go
@@ -1,0 +1,127 @@
+package agentstudio
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    HostOptions
+		want    string
+		wantErr error
+	}{
+		{
+			name: "override wins over everything",
+			opts: HostOptions{
+				Override:      "https://custom.example/",
+				Region:        RegionEU,
+				ApplicationID: "APP123",
+			},
+			want: "https://custom.example",
+		},
+		{
+			name:    "http override rejected without env",
+			opts:    HostOptions{Override: "http://localhost:8000"},
+			wantErr: nil,
+		},
+		{
+			name: "eu prod",
+			opts: HostOptions{Region: RegionEU},
+			want: "https://agent-studio.eu.algolia.com",
+		},
+		{
+			name: "us prod",
+			opts: HostOptions{Region: RegionUS, Env: EnvProd},
+			want: "https://agent-studio.us.algolia.com",
+		},
+		{
+			name: "eu staging",
+			opts: HostOptions{Region: RegionEU, Env: EnvStaging},
+			want: "https://agent-studio.staging.eu.algolia.com",
+		},
+		{
+			name:    "us staging is not supported",
+			opts:    HostOptions{Region: RegionUS, Env: EnvStaging},
+			wantErr: ErrStagingNotInRegion,
+		},
+		{
+			name: "region case-insensitive",
+			opts: HostOptions{Region: "EU"},
+			want: "https://agent-studio.eu.algolia.com",
+		},
+		{
+			name: "env case-insensitive",
+			opts: HostOptions{Region: RegionEU, Env: "STAGING"},
+			want: "https://agent-studio.staging.eu.algolia.com",
+		},
+		{
+			name:    "unknown region rejected",
+			opts:    HostOptions{Region: "apac"},
+			wantErr: ErrUnknownRegion,
+		},
+		{
+			name: "cluster-proxy fallback when region missing but appID present",
+			opts: HostOptions{ApplicationID: "APP123"},
+			want: "https://APP123.algolia.net/agent-studio",
+		},
+		{
+			name:    "cluster-proxy rejects non-alphanumeric app id",
+			opts:    HostOptions{ApplicationID: "evil.com#frag"},
+			wantErr: nil,
+		},
+		{
+			name:    "no inputs at all returns ErrNoHostResolvable",
+			opts:    HostOptions{},
+			wantErr: ErrNoHostResolvable,
+		},
+		{
+			name:    "unknown env rejected",
+			opts:    HostOptions{Region: RegionEU, Env: "preview"},
+			wantErr: nil, // sentinel-less; check via Contains below
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "cluster-proxy rejects non-alphanumeric app id" {
+				got, err := ResolveHost(tc.opts)
+				require.Error(t, err)
+				assert.Empty(t, got)
+				assert.Contains(t, err.Error(), "invalid application id")
+				return
+			}
+			if tc.name == "http override rejected without env" {
+				got, err := ResolveHost(tc.opts)
+				require.Error(t, err)
+				assert.Empty(t, got)
+				assert.Contains(t, err.Error(), "https://")
+				return
+			}
+			got, err := ResolveHost(tc.opts)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr), "got %v, want errors.Is(%v)", err, tc.wantErr)
+				return
+			}
+			if tc.name == "unknown env rejected" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unknown agent studio env")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestResolveHost_HTTPOverrideWithInsecureEnv(t *testing.T) {
+	t.Setenv(EnvAllowInsecureAgentStudioHTTP, "1")
+	got, err := ResolveHost(HostOptions{Override: "http://localhost:8000/agent-studio/"})
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8000/agent-studio", got)
+}

--- a/api/agentstudio/types.go
+++ b/api/agentstudio/types.go
@@ -1,0 +1,245 @@
+package agentstudio
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// AgentStatus is the lifecycle state of an agent.
+type AgentStatus string
+
+const (
+	StatusDraft     AgentStatus = "draft"
+	StatusPublished AgentStatus = "published"
+)
+
+// Agent mirrors AgentWithVersionResponse. Config and Tools are kept as
+// raw JSON; see docs/agents.md ("Pass-through bodies").
+type Agent struct {
+	ID           string          `json:"id"`
+	Name         string          `json:"name"`
+	Description  *string         `json:"description,omitempty"`
+	Status       AgentStatus     `json:"status"`
+	ProviderID   *string         `json:"providerId,omitempty"`
+	Model        *string         `json:"model,omitempty"`
+	Instructions string          `json:"instructions"`
+	SystemPrompt *string         `json:"systemPrompt,omitempty"`
+	Config       json.RawMessage `json:"config,omitempty"`
+	Tools        json.RawMessage `json:"tools,omitempty"`
+	TemplateType *string         `json:"templateType,omitempty"`
+	CreatedAt    time.Time       `json:"createdAt"`
+	UpdatedAt    *time.Time      `json:"updatedAt,omitempty"`
+	LastUsedAt   *time.Time      `json:"lastUsedAt,omitempty"`
+}
+
+// PaginationMetadata is the standard paginated-response envelope.
+type PaginationMetadata struct {
+	Page       int `json:"page"`
+	Limit      int `json:"limit"`
+	TotalCount int `json:"totalCount"`
+	TotalPages int `json:"totalPages"`
+}
+
+// PaginatedAgentsResponse is the GET /1/agents response.
+type PaginatedAgentsResponse struct {
+	Data       []Agent            `json:"data"`
+	Pagination PaginationMetadata `json:"pagination"`
+}
+
+// ListAgentsParams configures GET /1/agents. Page/Limit at 0 = server default.
+type ListAgentsParams struct {
+	Page       int
+	Limit      int
+	ProviderID string
+}
+
+// ProviderName values mirror the backend's ProviderName enum. Kept as
+// constants (not a typed enum) because the CLI passes the value through
+// verbatim from user JSON.
+const (
+	ProviderNameOpenAI           = "openai"
+	ProviderNameAzureOpenAI      = "azure_openai"
+	ProviderNameGoogleGenAI      = "google_genai"
+	ProviderNameDeepSeek         = "deepseek"
+	ProviderNameOpenAICompatible = "openai_compatible"
+	ProviderNameAnthropic        = "anthropic"
+)
+
+// AllProviderNames feeds help text and flag-validation lists.
+var AllProviderNames = []string{
+	ProviderNameOpenAI,
+	ProviderNameAzureOpenAI,
+	ProviderNameGoogleGenAI,
+	ProviderNameDeepSeek,
+	ProviderNameOpenAICompatible,
+	ProviderNameAnthropic,
+}
+
+// Provider mirrors ProviderAuthenticationResponse. Input is raw JSON
+// (discriminated union over ProviderName); see docs/agents.md.
+type Provider struct {
+	ID           string          `json:"id"`
+	Name         string          `json:"name"`
+	ProviderName string          `json:"providerName"`
+	Input        json.RawMessage `json:"input"`
+	CreatedAt    time.Time       `json:"createdAt"`
+	UpdatedAt    time.Time       `json:"updatedAt"`
+	LastUsedAt   *time.Time      `json:"lastUsedAt,omitempty"`
+}
+
+// PaginatedProvidersResponse is the GET /1/providers response.
+type PaginatedProvidersResponse struct {
+	Data       []Provider         `json:"data"`
+	Pagination PaginationMetadata `json:"pagination"`
+}
+
+// ListProvidersParams configures GET /1/providers.
+type ListProvidersParams struct {
+	Page  int
+	Limit int
+}
+
+// ApplicationConfig mirrors ApplicationConfigResponse.
+type ApplicationConfig struct {
+	MaxRetentionDays int `json:"maxRetentionDays"`
+}
+
+// Conversation mirrors ConversationBaseResponse (no messages — the
+// lightweight shape used in list responses).
+type Conversation struct {
+	ID                   string          `json:"id"`
+	AgentID              string          `json:"agentId"`
+	Title                *string         `json:"title,omitempty"`
+	CreatedAt            time.Time       `json:"createdAt"`
+	UpdatedAt            time.Time       `json:"updatedAt"`
+	LastActivityAt       *time.Time      `json:"lastActivityAt,omitempty"`
+	UserToken            *string         `json:"userToken,omitempty"`
+	IsFromDashboard      bool            `json:"isFromDashboard"`
+	MessageCount         int             `json:"messageCount"`
+	TotalInputTokens     int             `json:"totalInputTokens"`
+	TotalOutputTokens    int             `json:"totalOutputTokens"`
+	TotalTokens          int             `json:"totalTokens"`
+	Feedback             json.RawMessage `json:"feedback,omitempty"`
+	ConversationMetadata json.RawMessage `json:"conversationMetadata,omitempty"`
+}
+
+// PaginatedConversationsResponse is the list-conversations envelope.
+type PaginatedConversationsResponse struct {
+	Data       []Conversation     `json:"data"`
+	Pagination PaginationMetadata `json:"pagination"`
+}
+
+// ListConversationsParams configures GET /1/agents/{id}/conversations.
+// FeedbackVote is *int because nil = no filter while 0 (downvote) is a
+// meaningful value; backend silently drops the param unless
+// IncludeFeedback=true.
+type ListConversationsParams struct {
+	Page            int
+	Limit           int
+	StartDate       string
+	EndDate         string
+	IncludeFeedback bool
+	FeedbackVote    *int
+}
+
+// PurgeConversationsParams configures DELETE /1/agents/{id}/conversations.
+// Backend rejects dateless purge — see docs/agents.md gotchas.
+type PurgeConversationsParams struct {
+	StartDate string
+	EndDate   string
+}
+
+// ExportConversationsParams configures GET /1/agents/{id}/conversations/export.
+type ExportConversationsParams struct {
+	StartDate string
+	EndDate   string
+}
+
+// AllowedDomain mirrors AllowedDomainResponse.
+type AllowedDomain struct {
+	ID        string    `json:"id"`
+	AppID     string    `json:"appId"`
+	AgentID   string    `json:"agentId"`
+	Domain    string    `json:"domain"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// AllowedDomainListResponse is the un-paginated list shape for domains.
+type AllowedDomainListResponse struct {
+	Domains []AllowedDomain `json:"domains"`
+}
+
+// SecretKey mirrors SecretKeyResponse. Value is sensitive — always mask
+// unless the caller explicitly opts in.
+type SecretKey struct {
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	Value      string     `json:"value"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	UpdatedAt  time.Time  `json:"updatedAt"`
+	LastUsedAt *time.Time `json:"lastUsedAt"`
+	IsDefault  bool       `json:"isDefault"`
+	AgentIDs   []string   `json:"agentIds"`
+}
+
+// PaginatedSecretKeysResponse is the standard paginated envelope.
+type PaginatedSecretKeysResponse struct {
+	Data       []SecretKey        `json:"data"`
+	Pagination PaginationMetadata `json:"pagination"`
+}
+
+// ListSecretKeysParams configures GET /1/secret-keys.
+type ListSecretKeysParams struct {
+	Page  int
+	Limit int
+}
+
+// SecretKeyCreate is the POST body. AgentIDs is omitted when empty.
+type SecretKeyCreate struct {
+	Name     string   `json:"name"`
+	AgentIDs []string `json:"agentIds,omitempty"`
+}
+
+// SecretKeyPatch is the PATCH body. Pointer fields: nil = leave unchanged,
+// non-nil zero value = sent through (clears the field).
+type SecretKeyPatch struct {
+	Name     *string   `json:"name,omitempty"`
+	AgentIDs *[]string `json:"agentIds,omitempty"`
+}
+
+// FeedbackCreate is the POST body for /1/feedback. Vote is 0 (downvote)
+// or 1 (upvote); enforced at the CLI layer.
+type FeedbackCreate struct {
+	MessageID string   `json:"messageId"`
+	AgentID   string   `json:"agentId"`
+	Vote      int      `json:"vote"`
+	Tags      []string `json:"tags,omitempty"`
+	Notes     string   `json:"notes,omitempty"`
+}
+
+// Feedback mirrors FeedbackResponse.
+type Feedback struct {
+	ID        string    `json:"id"`
+	AgentID   string    `json:"agentId"`
+	MessageID string    `json:"messageId"`
+	Vote      int       `json:"vote"`
+	Tags      []string  `json:"tags"`
+	Notes     *string   `json:"notes"`
+	Model     *string   `json:"model"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// UserDataResponse mirrors GET /1/user-data/{user_token}. Inner items
+// are raw JSON (evolving schemas).
+type UserDataResponse struct {
+	Conversations []json.RawMessage `json:"conversations"`
+	Memories      []json.RawMessage `json:"memories"`
+}
+
+// StatusResponse mirrors GET /status.
+type StatusResponse map[string]*string
+
+// ModelDefaults mirrors GET /1/providers/models/defaults.
+type ModelDefaults map[string]string

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -9,6 +9,7 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/search"
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/transport"
 
+	"github.com/algolia/cli/api/agentstudio"
 	"github.com/algolia/cli/api/crawler"
 	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/config"
@@ -23,6 +24,7 @@ func New(appVersion string, cfg config.IConfig) *cmdutil.Factory {
 	f.IOStreams = ioStreams(f)
 	f.SearchClient = searchClient(f, appVersion)
 	f.CrawlerClient = crawlerClient(f)
+	f.AgentStudioClient = agentStudioClient(f, appVersion)
 
 	return f
 }
@@ -70,6 +72,42 @@ func searchClient(f *cmdutil.Factory, appVersion string) func() (*search.APIClie
 	}
 }
 
+func agentStudioClient(f *cmdutil.Factory, appVersion string) func() (*agentstudio.Client, error) {
+	return func() (*agentstudio.Client, error) {
+		profile := f.Config.Profile()
+		appID, err := profile.GetApplicationID()
+		if err != nil {
+			return nil, err
+		}
+		apiKey, err := profile.GetAPIKey()
+		if err != nil {
+			return nil, err
+		}
+
+		baseURL, err := resolveAgentStudioBaseURL(
+			profile.GetAgentStudioURL(),
+			agentstudio.DefaultBaseURL,
+			appID,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		userID := "cli"
+		if profile.Name != "" {
+			userID = "cli-" + profile.Name
+		}
+
+		return agentstudio.NewClient(agentstudio.Config{
+			BaseURL:       baseURL,
+			ApplicationID: appID,
+			APIKey:        apiKey,
+			UserID:        userID,
+			UserAgent:     fmt.Sprintf("algolia-cli/%s agentstudio", appVersion),
+		})
+	}
+}
+
 func crawlerClient(f *cmdutil.Factory) func() (*crawler.Client, error) {
 	return func() (*crawler.Client, error) {
 		userID, err := f.Config.Profile().GetCrawlerUserID()
@@ -83,6 +121,26 @@ func crawlerClient(f *cmdutil.Factory) func() (*crawler.Client, error) {
 
 		return crawler.NewClient(userID, APIKey), nil
 	}
+}
+
+// resolveAgentStudioBaseURL picks the Agent Studio base URL from, in order:
+//   - profileOverride (env var ALGOLIA_AGENT_STUDIO_URL or the profile's
+//     agent_studio_url field — both surfaced via Profile.GetAgentStudioURL),
+//   - buildDefault (the package-level agentstudio.DefaultBaseURL set via
+//     ldflags by `task build` from $ALGOLIA_AGENT_STUDIO_URL),
+//   - the cluster-proxy fallback https://<appID>.algolia.net/agent-studio.
+//
+// Extracted from agentStudioClient so the priority chain is exercised in
+// isolation by tests without needing a config mock.
+func resolveAgentStudioBaseURL(profileOverride, buildDefault, appID string) (string, error) {
+	override := profileOverride
+	if override == "" {
+		override = buildDefault
+	}
+	return agentstudio.ResolveHost(agentstudio.HostOptions{
+		Override:      override,
+		ApplicationID: appID,
+	})
 }
 
 // getUserAgentInfo returns the standard user agent info plus Algolia CLI

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -1,0 +1,66 @@
+package factory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_resolveAgentStudioBaseURL(t *testing.T) {
+	tests := []struct {
+		name            string
+		profileOverride string
+		buildDefault    string
+		appID           string
+		want            string
+		wantErr         bool
+	}{
+		{
+			name:            "profile override wins over build default",
+			profileOverride: "https://debug.example.com",
+			buildDefault:    "https://agent-studio.staging.eu.algolia.com",
+			appID:           "betaXYZ",
+			want:            "https://debug.example.com",
+		},
+		{
+			name:            "build default wins over cluster-proxy fallback when profile is empty",
+			profileOverride: "",
+			buildDefault:    "https://agent-studio.staging.eu.algolia.com",
+			appID:           "betaXYZ",
+			want:            "https://agent-studio.staging.eu.algolia.com",
+		},
+		{
+			name:            "cluster-proxy fallback when both overrides are empty",
+			profileOverride: "",
+			buildDefault:    "",
+			appID:           "APP123",
+			want:            "https://APP123.algolia.net/agent-studio",
+		},
+		{
+			name:            "trailing slash on profile override is trimmed",
+			profileOverride: "https://debug.example.com/",
+			buildDefault:    "",
+			appID:           "APP123",
+			want:            "https://debug.example.com",
+		},
+		{
+			name:            "missing appID with no overrides errors out",
+			profileOverride: "",
+			buildDefault:    "",
+			appID:           "",
+			wantErr:         true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveAgentStudioBaseURL(tc.profileOverride, tc.buildDefault, tc.appID)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -7,16 +7,18 @@ import (
 
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/search"
 
+	"github.com/algolia/cli/api/agentstudio"
 	"github.com/algolia/cli/api/crawler"
 	"github.com/algolia/cli/pkg/config"
 	"github.com/algolia/cli/pkg/iostreams"
 )
 
 type Factory struct {
-	IOStreams     *iostreams.IOStreams
-	Config        config.IConfig
-	SearchClient  func() (*search.APIClient, error)
-	CrawlerClient func() (*crawler.Client, error)
+	IOStreams         *iostreams.IOStreams
+	Config            config.IConfig
+	SearchClient      func() (*search.APIClient, error)
+	CrawlerClient     func() (*crawler.Client, error)
+	AgentStudioClient func() (*agentstudio.Client, error)
 
 	ExecutableName string
 }

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -21,6 +21,13 @@ type Profile struct {
 	AdminAPIKey   string   `mapstructure:"admin_api_key"`
 	SearchHosts   []string `mapstructure:"search_hosts"`
 
+	// AgentStudioURL is a per-profile override of the Agent Studio base URL.
+	// Resolution order at runtime is: env > profile > build-time default
+	// (api/agentstudio.DefaultBaseURL) > cluster-proxy fallback derived
+	// from ApplicationID. Mainly used for staging or local debug backends
+	// when a one-shot env var is too coarse.
+	AgentStudioURL string `mapstructure:"agent_studio_url"`
+
 	Default bool `mapstructure:"default"`
 }
 
@@ -173,6 +180,27 @@ func (p *Profile) GetCrawlerAPIKey() (string, error) {
 	}
 
 	return "", ErrCrawlerAPIKeyNotConfigured
+}
+
+// GetAgentStudioURL returns the Agent Studio base URL override, if any.
+// Resolution order matches GetApplicationID: env > profile struct > viper.
+// Empty string means "no override; let the client resolve from region/appID".
+func (p *Profile) GetAgentStudioURL() string {
+	if v := os.Getenv("ALGOLIA_AGENT_STUDIO_URL"); v != "" {
+		return v
+	}
+	if p.AgentStudioURL != "" {
+		return p.AgentStudioURL
+	}
+	if p.Name == "" {
+		p.LoadDefault()
+	}
+	if err := viper.ReadInConfig(); err == nil {
+		if v := viper.GetString(p.GetFieldName("agent_studio_url")); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // Add adds a profile to the configuration, preserving any existing profiles.


### PR DESCRIPTION
## Summary
- Introduces package `api/agentstudio`: `NewClient`, `ResolveHost`, structured error mapping (`checkResponse` / `extractDetail` / sentinels), and **typed client methods for the Agents REST tag** (same surface as `rag-openapi.json` → `GET/POST/PATCH/DELETE /1/agents/...`).
- Wires `AgentStudioClient func() (*agentstudio.Client, error)` on `cmdutil.Factory` (`pkg/cmd/factory`), with **`resolveAgentStudioBaseURL`** unit tests mirroring runtime precedence: profile/env override → ldflag `agentstudio.DefaultBaseURL` → cluster-proxy fallback.
- **Profile:** \`agent_studio_url\` + \`GetAgentStudioURL()\` (env \`ALGOLIA_AGENT_STUDIO_URL\` wins).
- **Build:** \`task build\` passes \`-X github.com/algolia/cli/api/agentstudio.DefaultBaseURL=$ALGOLIA_AGENT_STUDIO_URL\`; `.env.example` documents the var.

## Out of scope (follow-up PRs)
- No \`algolia agents\` Cobra commands or user docs yet — **PR-02** per [split plan](https://github.com/algolia/cli/blob/main/tmp/agents-releasable-split-plan.md) (file may live on contributor fork; link if missing).

## Base branch
- Opened against \`main\` (**algolia/cli has no \`development\` branch** — align with team if a different long-lived branch is preferred).

## QA / Anya — Phase 1 vetting
**Automated (required):** \`go test ./api/agentstudio/... ./pkg/cmd/factory/... -count=1\`, \`go test ./... -count=1\`, \`task lint\`, \`task build\`.

**Manual / exploratory**
1. **M01** — Confirm \`ResolveHost\` / URL precedence behaviour matches unit tests for your staging profile (no new CLI surface; optional HTTP probe with env-based credentials only — **no keys on argv**).
2. **M02** — Optional: single \`curl\` to staging \`GET …/1/agents\` with Search API key to confirm 401/200 class matches expectations.
3. **M03** — Review \`client_test.go\` error-mapping table for parity with FastAPI envelopes you have seen in \`conversational-ai\`.

**Sign-off:** Reply in-thread when automated + chosen manual rows are done.

## Test plan
- [x] \`go test ./api/agentstudio/...\`
- [x] \`go test ./pkg/cmd/factory/...\`
- [x] \`go test ./...\`
- [ ] \`task lint\` (CI)

Made with [Cursor](https://cursor.com)