### PR TITLE
feat(npm): switch CI auth from NPM_TOKEN to OIDC trusted publishing

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -5,7 +5,7 @@ on:
       - "v*"
 permissions:
   contents: write # publishing releases
-  id-token: write # OIDC token for npm provenance attestation
+  id-token: write # OIDC token for npm trusted publishing + provenance
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -51,7 +51,6 @@ jobs:
       - name: Publish npm packages
         env:
           VERSION: ${{ github.ref_name }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: ./scripts/npm-publish.sh
       - name: Docs checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Now that all 7 `@algolia/cli*` packages have trusted publishers configured on npmjs.org pointing at this repo's `releases.yml`, switch CI back to OIDC.
This should fix the current failing build because of OTP

## Follow-up cleanup

The `NPM_TOKEN` repo secret can be deleted once this lands.
