### PR TITLE
fix(npm): bump Node to 24 so OIDC trusted publishing works

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: Publish npm packages
         env:


### PR DESCRIPTION
## Summary

`v1.10.3` and `v1.10.4` releases failed at the npm publish step with:

```
npm notice publish Provenance statement published to transparency log
npm error 404 Not Found - PUT https://registry.npmjs.org/@algolia%2fcli-darwin-x64
```

The provenance step succeeded (uses OIDC directly), but the package upload failed despite trusted publishers being configured for all 7 packages.

**Root cause**: npm 10.x (shipped with Node 22) has an incomplete OIDC trusted-publishing implementation — it can sign provenance attestations using the GitHub Actions OIDC token, but doesn't fall through to OIDC for authenticating the actual package PUT. npm 11.6+ (shipped with Node 24) handles the flow end-to-end.

Reference: https://github.com/npm/cli/issues/8730#issuecomment-3538909998 — Jason3S confirms Node 22 doesn't work, Node 24 with npm 11.6.2 does.

## Change

Single-line bump: `node-version: "22"` → `"24"`.
