### PR TITLE
docs(npm): lead with npx in README usage section

### DIFF
--- a/npm/algolia/README.md
+++ b/npm/algolia/README.md
@@ -4,22 +4,24 @@ The official Algolia CLI lets you manage your Algolia resources — indices, rec
 
 > This package installs a prebuilt Go binary. The npm wrapper still requires Node.js to launch the installed command.
 
-## Installation
+## Usage
 
-```sh
-npm install -g @algolia/cli
-```
-
-Or run without installing:
+Run without installing:
 
 ```sh
 npx @algolia/cli --help
 ```
 
-## Usage
+Or install globally:
 
 ```sh
+npm install -g @algolia/cli
 algolia --help
+```
+
+## Examples
+
+```sh
 algolia search --index my-index --query "foo"
 algolia indices list
 algolia apikeys list


### PR DESCRIPTION
## Summary
- Reorganize `npm/algolia/README.md` so `npx @algolia/cli` is the primary install path, with `npm install -g` shown as a fallback.
- Split command snippets into a dedicated `## Examples` section.

## Test plan
- [ ] Render the README on npm after the next publish and confirm `npx` is the first thing readers see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)