### PR TITLE
docs: add npm install option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ See [Algolia CLI](https://algolia.com/doc/tools/cli/) in the Algolia documentati
 
 ## Installation
 
+### npm (any platform)
+
+The Algolia CLI is published on npm as [`@algolia/cli`](https://www.npmjs.com/package/@algolia/cli).
+
+Run without installing:
+
+```sh
+npx @algolia/cli --help
+```
+
+Or install globally:
+
+```sh
+npm install -g @algolia/cli
+```
+
 ### macOS
 
 The Algolia CLI is available on [Homebrew](https://brew.sh/) and as a downloadable binary from the [releases page](https://github.com/algolia/cli/releases).


### PR DESCRIPTION
## Summary
- Document `@algolia/cli` as an install option in the repo README.
- Positioned above the OS-specific sections since npm works on every supported platform.

## Test plan
- [ ] Render the README on GitHub and confirm the new section is the first under Installation.


Related docs PR: https://github.com/algolia/docs-new/pull/839 

🤖 Generated with [Claude Code](https://claude.com/claude-code)