### PR TITLE
feat(application): update/upgrade/downgrade/plans commands

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,14 @@ linters:
     - gosec
     - gofumpt
     - stylecheck
+
+issues:
+  exclude-rules:
+    # The dashboard client surfaces user-facing CLI errors that are intentionally
+    # written as capitalized, human-readable sentences (e.g. "Couldn't get the
+    # list of plans: 404"), so the ST1005 "error strings should not be
+    # capitalized" check is disabled for this file only.
+    - path: api/dashboard/client.go
+      linters:
+        - stylecheck
+      text: ST1005

--- a/api/dashboard/client.go
+++ b/api/dashboard/client.go
@@ -400,6 +400,112 @@ func (c *Client) UpdateApplication(accessToken, appID, name string) (*Applicatio
 	return &app, nil
 }
 
+// GetSelfServePlans returns the available plans
+func (c *Client) GetSelfServePlans(accessToken string) ([]Plan, error) {
+	req, err := http.NewRequest(http.MethodGet, c.APIURL+"/1/plan-templates/self-serve", nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAPIHeaders(req, accessToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get the list of plans: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrSessionExpired
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Couldn't get the list of plans: %d", resp.StatusCode)
+	}
+
+	var plansResp PlanTemplatesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&plansResp); err != nil {
+		return nil, fmt.Errorf("Couldn't get the list of plans: %w", err)
+	}
+
+	plans := make([]Plan, 0, len(plansResp.Data))
+	for i := range plansResp.Data {
+		plans = append(plans, plansResp.Data[i].toPlan())
+	}
+	return plans, nil
+}
+
+// GetUser returns account-level information for the authenticated user
+func (c *Client) GetUser(accessToken string) (*DashboardUser, error) {
+	req, err := http.NewRequest(http.MethodGet, c.APIURL+"/1/user", nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAPIHeaders(req, accessToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get your account details: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrSessionExpired
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Couldn't get your account details: %d", resp.StatusCode)
+	}
+
+	var userResp userResponse
+	if err := json.NewDecoder(resp.Body).Decode(&userResp); err != nil {
+		return nil, fmt.Errorf("Couldn't get your account details: %w", err)
+	}
+
+	user := userResp.toUser()
+	return &user, nil
+}
+
+// ChangeApplicationPlan changes the plan of an application
+func (c *Client) ChangeApplicationPlan(accessToken, appID, plan string) (*Application, error) {
+	payload := ChangePlanRequest{Plan: plan}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf(
+		"%s/1/applications/%s/plan/self-serve",
+		c.APIURL,
+		url.PathEscape(appID),
+	)
+	req, err := http.NewRequest(http.MethodPatch, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	c.setAPIHeaders(req, accessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't change your application's plan: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrSessionExpired
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Couldn't change your application's plan: %d", resp.StatusCode)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var singleResp SingleApplicationResponse
+	if err := json.Unmarshal(respBody, &singleResp); err == nil &&
+		singleResp.Data.Attributes.ApplicationID != "" {
+		app := singleResp.Data.toApplication()
+		return &app, nil
+	}
+	return &Application{ID: appID}, nil
+}
+
 // ListRegions returns the allowed hosting regions for application creation.
 func (c *Client) ListRegions(accessToken string) ([]Region, error) {
 	req, err := http.NewRequest(http.MethodGet, c.APIURL+"/1/hosting/regions", nil)

--- a/api/dashboard/client.go
+++ b/api/dashboard/client.go
@@ -36,7 +36,10 @@ func NewClient(clientID string) *Client {
 		dashboardURL = strings.TrimRight(v, "/")
 	}
 	if dashboardURL == "" {
-		fmt.Fprintln(os.Stderr, "fatal: ALGOLIA_DASHBOARD_URL is not set and no default was compiled in")
+		fmt.Fprintln(
+			os.Stderr,
+			"fatal: ALGOLIA_DASHBOARD_URL is not set and no default was compiled in",
+		)
 		os.Exit(1)
 	}
 
@@ -54,7 +57,10 @@ func NewClient(clientID string) *Client {
 		oauthScope = v
 	}
 	if oauthScope == "" {
-		fmt.Fprintln(os.Stderr, "fatal: ALGOLIA_OAUTH_SCOPE is not set and no default was compiled in")
+		fmt.Fprintln(
+			os.Stderr,
+			"fatal: ALGOLIA_OAUTH_SCOPE is not set and no default was compiled in",
+		)
 		os.Exit(1)
 	}
 
@@ -87,7 +93,10 @@ func (c *Client) SignupAuthorizeURL(codeChallenge, redirectURI string) string {
 	return c.buildAuthorizeURL(codeChallenge, redirectURI, map[string]string{"screen": "signup"})
 }
 
-func (c *Client) buildAuthorizeURL(codeChallenge, redirectURI string, extra map[string]string) string {
+func (c *Client) buildAuthorizeURL(
+	codeChallenge, redirectURI string,
+	extra map[string]string,
+) string {
 	params := url.Values{
 		"client_id":             {c.ClientID},
 		"response_type":         {"code"},
@@ -104,7 +113,9 @@ func (c *Client) buildAuthorizeURL(codeChallenge, redirectURI string, extra map[
 
 // AuthorizationCodeGrant exchanges an authorization code + PKCE code_verifier
 // for an access token. The redirectURI must match the one used in the authorize URL.
-func (c *Client) AuthorizationCodeGrant(code, codeVerifier, redirectURI string) (*OAuthTokenResponse, error) {
+func (c *Client) AuthorizationCodeGrant(
+	code, codeVerifier, redirectURI string,
+) (*OAuthTokenResponse, error) {
 	form := url.Values{
 		"grant_type":    {"authorization_code"},
 		"client_id":     {c.ClientID},
@@ -113,7 +124,11 @@ func (c *Client) AuthorizationCodeGrant(code, codeVerifier, redirectURI string) 
 		"redirect_uri":  {redirectURI},
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.DashboardURL+"/2/oauth/token", strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.DashboardURL+"/2/oauth/token",
+		strings.NewReader(form.Encode()),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +161,11 @@ func (c *Client) RefreshToken(refreshToken string) (*OAuthTokenResponse, error) 
 		"refresh_token": {refreshToken},
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.DashboardURL+"/2/oauth/token", strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.DashboardURL+"/2/oauth/token",
+		strings.NewReader(form.Encode()),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +197,11 @@ func (c *Client) RevokeToken(token string) error {
 		"token":     {token},
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.DashboardURL+"/2/oauth/revoke", strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.DashboardURL+"/2/oauth/revoke",
+		strings.NewReader(form.Encode()),
+	)
 	if err != nil {
 		return err
 	}
@@ -246,7 +269,11 @@ func (c *Client) ListApplications(accessToken string) ([]Application, error) {
 
 // GetApplication returns a single application by its ID.
 func (c *Client) GetApplication(accessToken, appID string) (*Application, error) {
-	req, err := http.NewRequest(http.MethodGet, c.APIURL+"/1/application/"+url.PathEscape(appID), nil)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		c.APIURL+"/1/application/"+url.PathEscape(appID),
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -299,12 +326,69 @@ func (c *Client) CreateApplication(accessToken, region, name string) (*Applicati
 		respBody, _ := io.ReadAll(resp.Body)
 		respStr := string(respBody)
 
-		if strings.Contains(strings.ToLower(respStr), "cluster") && strings.Contains(strings.ToLower(respStr), "not available") ||
+		if strings.Contains(strings.ToLower(respStr), "cluster") &&
+			strings.Contains(strings.ToLower(respStr), "not available") ||
 			strings.Contains(strings.ToLower(respStr), "no cluster") {
-			return nil, &ErrClusterUnavailable{Region: region, Message: fmt.Sprintf("no cluster available in region %q", region)}
+			return nil, &ErrClusterUnavailable{
+				Region:  region,
+				Message: fmt.Sprintf("no cluster available in region %q", region),
+			}
 		}
 
-		return nil, fmt.Errorf("create application failed with status %d: %s", resp.StatusCode, respStr)
+		return nil, fmt.Errorf(
+			"create application failed with status %d: %s",
+			resp.StatusCode,
+			respStr,
+		)
+	}
+
+	var singleResp SingleApplicationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&singleResp); err != nil {
+		return nil, fmt.Errorf("failed to parse application response: %w", err)
+	}
+
+	app := singleResp.Data.toApplication()
+	return &app, nil
+}
+
+// UpdateApplication renames an existing application.
+func (c *Client) UpdateApplication(accessToken, appID, name string) (*Application, error) {
+	payload := UpdateApplicationRequest{Name: name}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := c.APIURL + "/1/applications/" + url.PathEscape(appID)
+	req, err := http.NewRequest(http.MethodPatch, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	c.setAPIHeaders(req, accessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("update application request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrSessionExpired
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf(
+				"no existing application found; select one using 'algolia application select' or create a new one with 'algolia application create'",
+			)
+		}
+		return nil, fmt.Errorf(
+			"update application failed with status %d: %s",
+			resp.StatusCode,
+			string(respBody),
+		)
 	}
 
 	var singleResp SingleApplicationResponse
@@ -350,7 +434,11 @@ var WriteACL = []string{
 }
 
 // CreateAPIKey creates a new API key with the given ACL for the specified application.
-func (c *Client) CreateAPIKey(accessToken, appID string, acl []string, description string) (string, error) {
+func (c *Client) CreateAPIKey(
+	accessToken, appID string,
+	acl []string,
+	description string,
+) (string, error) {
 	payload := CreateAPIKeyRequest{ACL: acl, Description: description}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -377,17 +465,28 @@ func (c *Client) CreateAPIKey(accessToken, appID string, acl []string, descripti
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("create API key failed with status %d: %s", resp.StatusCode, string(respBody))
+		return "", fmt.Errorf(
+			"create API key failed with status %d: %s",
+			resp.StatusCode,
+			string(respBody),
+		)
 	}
 
 	var keyResp CreateAPIKeyResponse
 	if err := json.Unmarshal(respBody, &keyResp); err != nil {
-		return "", fmt.Errorf("failed to parse API key response: %w (body: %s)", err, string(respBody))
+		return "", fmt.Errorf(
+			"failed to parse API key response: %w (body: %s)",
+			err,
+			string(respBody),
+		)
 	}
 
 	key := keyResp.Data.Attributes.Value
 	if key == "" {
-		return "", fmt.Errorf("API key creation succeeded but no key was returned in the response: %s", string(respBody))
+		return "", fmt.Errorf(
+			"API key creation succeeded but no key was returned in the response: %s",
+			string(respBody),
+		)
 	}
 
 	return key, nil

--- a/api/dashboard/client_test.go
+++ b/api/dashboard/client_test.go
@@ -278,7 +278,7 @@ func TestCreateApplication_Success(t *testing.T) {
 
 func TestUpdateApplication_Success(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/1/application/APP1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/1/applications/APP1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
 		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
@@ -306,7 +306,7 @@ func TestUpdateApplication_Success(t *testing.T) {
 
 func TestUpdateApplication_Unauthorized(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/1/application/APP1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/1/applications/APP1", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	})
 
@@ -320,7 +320,7 @@ func TestUpdateApplication_Unauthorized(t *testing.T) {
 
 func TestUpdateApplication_ErrorStatus(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/1/application/APP1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/1/applications/APP1", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		_, err := w.Write([]byte(`{"errors":[{"title":"name has already been taken"}]}`))
 		require.NoError(t, err)
@@ -333,6 +333,199 @@ func TestUpdateApplication_ErrorStatus(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "update application failed with status 422")
 	assert.Contains(t, err.Error(), "name has already been taken")
+}
+
+func TestGetSelfServePlans_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/plan-templates/self-serve", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		require.NoError(t, json.NewEncoder(w).Encode(PlanTemplatesResponse{
+			Data: []PlanTemplateResource{
+				{
+					ID:   "build",
+					Type: "plan_template",
+					Attributes: PlanTemplateAttributes{
+						Name:        "Build",
+						Description: "Free forever Search & Discovery API.",
+						Type:        "free",
+						Configuration: PlanTemplateConfiguration{
+							Plan:        "build",
+							AcceptTerms: "Build terms",
+						},
+					},
+				},
+				{
+					ID:   "grow",
+					Type: "plan_template",
+					Attributes: PlanTemplateAttributes{
+						Name:        "Grow",
+						Description: "Best-in-class Search & Discovery API with free tier.",
+						Type:        "freeform",
+						Freeform:    "$0.50 / 1,000 Requests",
+						Configuration: PlanTemplateConfiguration{
+							Plan:        "grow",
+							AcceptTerms: "Grow terms",
+						},
+					},
+				},
+			},
+		}))
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	plans, err := client.GetSelfServePlans("test-token")
+	require.NoError(t, err)
+	require.Len(t, plans, 2)
+
+	// The free-type plan keeps its configuration.plan id and prices as "Free".
+	assert.Equal(t, "build", plans[0].ID)
+	assert.Equal(t, "Build", plans[0].Name)
+	assert.Equal(t, "free", plans[0].Type)
+	assert.Equal(t, "Free", plans[0].Price)
+	assert.Equal(t, "Build terms", plans[0].AcceptTerms)
+
+	// Freeform plans surface the freeform pricing string.
+	assert.Equal(t, "grow", plans[1].ID)
+	assert.Equal(t, "$0.50 / 1,000 Requests", plans[1].Price)
+}
+
+func TestGetSelfServePlans_Unauthorized(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/plan-templates/self-serve", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	_, err := client.GetSelfServePlans("expired-token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session expired")
+}
+
+func TestGetUser_TopLevel(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/user", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		_, err := w.Write([]byte(`{"has_payment_method": true, "plan": "grow"}`))
+		require.NoError(t, err)
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	user, err := client.GetUser("test-token")
+	require.NoError(t, err)
+	assert.True(t, user.HasPaymentMethod)
+}
+
+func TestGetUser_DataAttributes(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/user", func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write(
+			[]byte(
+				`{"data":{"attributes":{"has_payment_method": false, "current_plan": "build"}}}`,
+			),
+		)
+		require.NoError(t, err)
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	user, err := client.GetUser("test-token")
+	require.NoError(t, err)
+	assert.False(t, user.HasPaymentMethod)
+}
+
+func TestChangeApplicationPlan_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/1/applications/APP1/plan/self-serve",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPatch, r.Method)
+			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			var payload ChangePlanRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+			assert.Equal(t, "grow", payload.Plan)
+
+			require.NoError(t, json.NewEncoder(w).Encode(SingleApplicationResponse{
+				Data: ApplicationResource{
+					ID: "APP1", Type: "application",
+					Attributes: ApplicationAttributes{ApplicationID: "APP1", Name: "My App"},
+				},
+			}))
+		},
+	)
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	app, err := client.ChangeApplicationPlan("test-token", "APP1", "grow")
+	require.NoError(t, err)
+	assert.Equal(t, "APP1", app.ID)
+	assert.Equal(t, "My App", app.Name)
+}
+
+func TestChangeApplicationPlan_EmptyBodyFallback(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/1/applications/APP1/plan/self-serve",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	// An empty/204 body still yields a usable result with the known app ID.
+	app, err := client.ChangeApplicationPlan("test-token", "APP1", "free")
+	require.NoError(t, err)
+	assert.Equal(t, "APP1", app.ID)
+}
+
+func TestChangeApplicationPlan_Unauthorized(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/1/applications/APP1/plan/self-serve",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	)
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	_, err := client.ChangeApplicationPlan("expired-token", "APP1", "grow")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session expired")
+}
+
+func TestChangeApplicationPlan_ErrorStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/1/applications/APP1/plan/self-serve",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, err := w.Write([]byte(`{"errors":[{"title":"plan change not allowed"}]}`))
+			require.NoError(t, err)
+		},
+	)
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	_, err := client.ChangeApplicationPlan("test-token", "APP1", "grow")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Couldn't change your application's plan: 422")
+	// The response body must never be surfaced in the error, only the status.
+	assert.NotContains(t, err.Error(), "plan change not allowed")
 }
 
 func TestGetCrawlerUser_Success(t *testing.T) {

--- a/api/dashboard/client_test.go
+++ b/api/dashboard/client_test.go
@@ -64,7 +64,11 @@ func TestAuthorizationCodeGrant_Success(t *testing.T) {
 	ts, client := newTestClient(mux)
 	defer ts.Close()
 
-	resp, err := client.AuthorizationCodeGrant("auth-code-123", "verifier-xyz", "http://localhost:12345")
+	resp, err := client.AuthorizationCodeGrant(
+		"auth-code-123",
+		"verifier-xyz",
+		"http://localhost:12345",
+	)
 	require.NoError(t, err)
 	assert.Equal(t, "access-token-123", resp.AccessToken)
 	assert.Equal(t, "refresh-token-456", resp.RefreshToken)
@@ -118,8 +122,24 @@ func TestListApplications_Success(t *testing.T) {
 		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 		require.NoError(t, json.NewEncoder(w).Encode(ApplicationsResponse{
 			Data: []ApplicationResource{
-				{ID: "APP1", Type: "application", Attributes: ApplicationAttributes{ApplicationID: "APP1", Name: "My App", APIKey: "key1"}},
-				{ID: "APP2", Type: "application", Attributes: ApplicationAttributes{ApplicationID: "APP2", Name: "Other App", APIKey: "key2"}},
+				{
+					ID:   "APP1",
+					Type: "application",
+					Attributes: ApplicationAttributes{
+						ApplicationID: "APP1",
+						Name:          "My App",
+						APIKey:        "key1",
+					},
+				},
+				{
+					ID:   "APP2",
+					Type: "application",
+					Attributes: ApplicationAttributes{
+						ApplicationID: "APP2",
+						Name:          "Other App",
+						APIKey:        "key2",
+					},
+				},
 			},
 		}))
 	})
@@ -145,15 +165,30 @@ func TestListApplications_Paginated(t *testing.T) {
 		case "2":
 			require.NoError(t, json.NewEncoder(w).Encode(ApplicationsResponse{
 				Data: []ApplicationResource{
-					{ID: "APP3", Type: "application", Attributes: ApplicationAttributes{ApplicationID: "APP3", Name: "Third App"}},
+					{
+						ID:         "APP3",
+						Type:       "application",
+						Attributes: ApplicationAttributes{ApplicationID: "APP3", Name: "Third App"},
+					},
 				},
 				Meta: PaginationMeta{TotalCount: 3, PerPage: 2, CurrentPage: 2, TotalPages: 2},
 			}))
 		default:
 			require.NoError(t, json.NewEncoder(w).Encode(ApplicationsResponse{
 				Data: []ApplicationResource{
-					{ID: "APP1", Type: "application", Attributes: ApplicationAttributes{ApplicationID: "APP1", Name: "First App"}},
-					{ID: "APP2", Type: "application", Attributes: ApplicationAttributes{ApplicationID: "APP2", Name: "Second App"}},
+					{
+						ID:         "APP1",
+						Type:       "application",
+						Attributes: ApplicationAttributes{ApplicationID: "APP1", Name: "First App"},
+					},
+					{
+						ID:   "APP2",
+						Type: "application",
+						Attributes: ApplicationAttributes{
+							ApplicationID: "APP2",
+							Name:          "Second App",
+						},
+					},
 				},
 				Meta: PaginationMeta{TotalCount: 3, PerPage: 2, CurrentPage: 1, TotalPages: 2},
 			}))
@@ -193,7 +228,11 @@ func TestGetApplication_Success(t *testing.T) {
 		require.NoError(t, json.NewEncoder(w).Encode(SingleApplicationResponse{
 			Data: ApplicationResource{
 				ID: "APP1", Type: "application",
-				Attributes: ApplicationAttributes{ApplicationID: "APP1", Name: "My App", APIKey: "api-key-123"},
+				Attributes: ApplicationAttributes{
+					ApplicationID: "APP1",
+					Name:          "My App",
+					APIKey:        "api-key-123",
+				},
 			},
 		}))
 	})
@@ -235,6 +274,65 @@ func TestCreateApplication_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "NEW_APP", app.ID)
 	assert.Equal(t, "My App", app.Name)
+}
+
+func TestUpdateApplication_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/application/APP1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var payload UpdateApplicationRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		assert.Equal(t, "Renamed App", payload.Name)
+
+		require.NoError(t, json.NewEncoder(w).Encode(SingleApplicationResponse{
+			Data: ApplicationResource{
+				ID: "APP1", Type: "application",
+				Attributes: ApplicationAttributes{ApplicationID: "APP1", Name: "Renamed App"},
+			},
+		}))
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	app, err := client.UpdateApplication("test-token", "APP1", "Renamed App")
+	require.NoError(t, err)
+	assert.Equal(t, "APP1", app.ID)
+	assert.Equal(t, "Renamed App", app.Name)
+}
+
+func TestUpdateApplication_Unauthorized(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/application/APP1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	_, err := client.UpdateApplication("expired-token", "APP1", "Renamed App")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session expired")
+}
+
+func TestUpdateApplication_ErrorStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/application/APP1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, err := w.Write([]byte(`{"errors":[{"title":"name has already been taken"}]}`))
+		require.NoError(t, err)
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	_, err := client.UpdateApplication("test-token", "APP1", "Taken Name")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update application failed with status 422")
+	assert.Contains(t, err.Error(), "name has already been taken")
 }
 
 func TestGetCrawlerUser_Success(t *testing.T) {

--- a/api/dashboard/types.go
+++ b/api/dashboard/types.go
@@ -76,6 +76,11 @@ type CreateApplicationRequest struct {
 	Name       string `json:"name"`
 }
 
+// UpdateApplicationRequest is the payload for PATCH /1/application/{id}.
+type UpdateApplicationRequest struct {
+	Name string `json:"name"`
+}
+
 // Region represents a hosting region from GET /1/hosting/regions.
 type Region struct {
 	Code string `json:"code"`

--- a/api/dashboard/types.go
+++ b/api/dashboard/types.go
@@ -76,7 +76,7 @@ type CreateApplicationRequest struct {
 	Name       string `json:"name"`
 }
 
-// UpdateApplicationRequest is the payload for PATCH /1/application/{id}.
+// UpdateApplicationRequest is the payload for PATCH /1/applications/{id}.
 type UpdateApplicationRequest struct {
 	Name string `json:"name"`
 }
@@ -164,4 +164,111 @@ func (r *ApplicationResource) toApplication() Application {
 		Name:   r.Attributes.Name,
 		APIKey: r.Attributes.APIKey,
 	}
+}
+
+// PlanTypeFree is the attributes.type value that identifies the free-tier plan
+// template. The free plan's configuration.plan id is not fixed (it can be
+// "build"), so the CLI keys off this type rather than a hard-coded id when it
+// needs to map the user-facing "free" choice to a concrete plan.
+const PlanTypeFree = "free"
+
+// PlanTemplatesResponse is the JSON:API response from GET /1/plan-templates/self-serve.
+type PlanTemplatesResponse struct {
+	Data []PlanTemplateResource `json:"data"`
+}
+
+// PlanTemplateResource is a JSON:API resource wrapper for a self-serve plan template.
+type PlanTemplateResource struct {
+	ID         string                 `json:"id"`
+	Type       string                 `json:"type"`
+	Attributes PlanTemplateAttributes `json:"attributes"`
+}
+
+// PlanTemplateAttributes contains the actual plan template fields.
+type PlanTemplateAttributes struct {
+	Name          string                    `json:"name"`
+	Description   string                    `json:"description"`
+	Type          string                    `json:"type"`               // e.g. "free" or "freeform"
+	Freeform      string                    `json:"freeform,omitempty"` // pricing string for paygo plans
+	Configuration PlanTemplateConfiguration `json:"configuration"`
+}
+
+// PlanTemplateConfiguration holds the plan identifier and the terms text.
+type PlanTemplateConfiguration struct {
+	Plan        string `json:"plan"`
+	AcceptTerms string `json:"accept_terms"`
+}
+
+// Plan is a flattened, CLI-friendly view of a self-serve plan template.
+type Plan struct {
+	ID          string `json:"id"`           // configuration.plan (e.g. "build", "grow", "grow-plus")
+	Name        string `json:"name"`         // human-readable name (e.g. "Grow Plus")
+	Description string `json:"description"`  // short description
+	Type        string `json:"type"`         // "free" or "freeform"
+	Price       string `json:"price"`        // "Free" for the free plan, otherwise the freeform pricing string
+	AcceptTerms string `json:"accept_terms"` // ToS text shown before changing the plan
+}
+
+// IsFree reports whether the plan is the free-tier plan (no payment method required).
+func (p Plan) IsFree() bool {
+	return p.Type == PlanTypeFree
+}
+
+// toPlan flattens a JSON:API plan template resource into a Plan.
+func (r *PlanTemplateResource) toPlan() Plan {
+	// The free plan template has no "freeform" pricing field, so present a
+	// friendly "Free" instead of an empty string.
+	price := r.Attributes.Freeform
+	if r.Attributes.Type == PlanTypeFree || price == "" {
+		price = "Free"
+	}
+	return Plan{
+		ID:          r.Attributes.Configuration.Plan,
+		Name:        r.Attributes.Name,
+		Description: r.Attributes.Description,
+		Type:        r.Attributes.Type,
+		Price:       price,
+		AcceptTerms: r.Attributes.Configuration.AcceptTerms,
+	}
+}
+
+// ChangePlanRequest is the payload for PATCH /1/applications/{id}/plan/self-serve.
+//
+// Every request body in this client is a plain JSON object (see
+// CreateApplicationRequest and UpdateApplicationRequest) rather than a JSON:API
+// data.attributes envelope, so we mirror that existing convention here.
+type ChangePlanRequest struct {
+	Plan string `json:"plan"`
+}
+
+// DashboardUser is a flattened view of the authenticated user's account info
+// from GET /1/user, exposing only what plan changes need.
+type DashboardUser struct {
+	HasPaymentMethod bool `json:"has_payment_method"`
+}
+
+// userResponse is a forgiving decoder for GET /1/user. The exact shape of this
+// endpoint is not documented for the CLI, so we accept "has_payment_method"
+// either at the top level or nested under a JSON:API data.attributes object,
+// and use whichever is present.
+type userResponse struct {
+	HasPaymentMethod *bool `json:"has_payment_method"`
+	Data             *struct {
+		Attributes struct {
+			HasPaymentMethod *bool `json:"has_payment_method"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+func (r *userResponse) toUser() DashboardUser {
+	u := DashboardUser{}
+
+	switch {
+	case r.HasPaymentMethod != nil:
+		u.HasPaymentMethod = *r.HasPaymentMethod
+	case r.Data != nil && r.Data.Attributes.HasPaymentMethod != nil:
+		u.HasPaymentMethod = *r.Data.Attributes.HasPaymentMethod
+	}
+
+	return u
 }

--- a/pkg/cmd/application/application.go
+++ b/pkg/cmd/application/application.go
@@ -4,9 +4,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/algolia/cli/pkg/cmd/application/create"
+	"github.com/algolia/cli/pkg/cmd/application/downgrade"
 	"github.com/algolia/cli/pkg/cmd/application/list"
+	"github.com/algolia/cli/pkg/cmd/application/plans"
 	"github.com/algolia/cli/pkg/cmd/application/selectapp"
 	"github.com/algolia/cli/pkg/cmd/application/update"
+	"github.com/algolia/cli/pkg/cmd/application/upgrade"
 	"github.com/algolia/cli/pkg/cmdutil"
 )
 
@@ -22,6 +25,9 @@ func NewApplicationCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(list.NewListCmd(f))
 	cmd.AddCommand(selectapp.NewSelectCmd(f))
 	cmd.AddCommand(update.NewUpdateCmd(f))
+	cmd.AddCommand(plans.NewPlansCmd(f))
+	cmd.AddCommand(upgrade.NewUpgradeCmd(f))
+	cmd.AddCommand(downgrade.NewDowngradeCmd(f))
 
 	return cmd
 }

--- a/pkg/cmd/application/application.go
+++ b/pkg/cmd/application/application.go
@@ -6,6 +6,7 @@ import (
 	"github.com/algolia/cli/pkg/cmd/application/create"
 	"github.com/algolia/cli/pkg/cmd/application/list"
 	"github.com/algolia/cli/pkg/cmd/application/selectapp"
+	"github.com/algolia/cli/pkg/cmd/application/update"
 	"github.com/algolia/cli/pkg/cmdutil"
 )
 
@@ -20,6 +21,7 @@ func NewApplicationCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(create.NewCreateCmd(f))
 	cmd.AddCommand(list.NewListCmd(f))
 	cmd.AddCommand(selectapp.NewSelectCmd(f))
+	cmd.AddCommand(update.NewUpdateCmd(f))
 
 	return cmd
 }

--- a/pkg/cmd/application/downgrade/downgrade.go
+++ b/pkg/cmd/application/downgrade/downgrade.go
@@ -1,0 +1,64 @@
+package downgrade
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/cmd/application/planchange"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+func NewDowngradeCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &planchange.Options{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		PrintFlags: cmdutil.NewPrintFlags(),
+		NewDashboardClient: func(clientID string) *dashboard.Client {
+			return dashboard.NewClient(clientID)
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "downgrade",
+		Short: "Downgrade the current application to a lower-tier plan",
+		Long: heredoc.Doc(`
+			Change the application associated with the current CLI profile to a
+			lower-tier self-serve plan.
+
+			You must accept the target plan's terms of service before the change
+			is applied.
+		`),
+		Example: heredoc.Doc(`
+			# Pick a lower-tier plan interactively
+			$ algolia application downgrade
+
+			# Downgrade to a specific plan
+			$ algolia application downgrade --plan free
+
+			# Non-interactive (accept terms up front)
+			$ algolia application downgrade --plan grow --accept-terms
+
+			# Preview the change without applying it
+			$ algolia application downgrade --plan free --dry-run
+		`),
+		Args: validators.NoArgs(),
+		Annotations: map[string]string{
+			"skipAuthCheck": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return planchange.Run(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Plan, "plan", "", "Target plan (free, grow, grow-plus)")
+	cmd.Flags().
+		BoolVar(&opts.DryRun, "dry-run", false, "Preview the plan change without applying it")
+	cmd.Flags().
+		BoolVarP(&opts.AcceptTerms, "accept-terms", "y", false, "Accept the plan terms of service (required in non-interactive mode)")
+
+	opts.PrintFlags.AddFlags(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/application/downgrade/downgrade_test.go
+++ b/pkg/cmd/application/downgrade/downgrade_test.go
@@ -1,0 +1,25 @@
+package downgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/test"
+)
+
+func TestNewDowngradeCmd(t *testing.T) {
+	f, _ := test.NewFactory(false, nil, nil, "")
+	cmd := NewDowngradeCmd(f)
+
+	assert.Equal(t, "downgrade", cmd.Name())
+	assert.Equal(t, "true", cmd.Annotations["skipAuthCheck"])
+
+	require.NotNil(t, cmd.Flags().Lookup("plan"))
+	require.NotNil(t, cmd.Flags().Lookup("dry-run"))
+
+	acceptTerms := cmd.Flags().Lookup("accept-terms")
+	require.NotNil(t, acceptTerms)
+	assert.Equal(t, "y", acceptTerms.Shorthand)
+}

--- a/pkg/cmd/application/planchange/planchange.go
+++ b/pkg/cmd/application/planchange/planchange.go
@@ -15,6 +15,7 @@ import (
 	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/config"
 	"github.com/algolia/cli/pkg/iostreams"
+	pkgopen "github.com/algolia/cli/pkg/open"
 	"github.com/algolia/cli/pkg/prompt"
 )
 
@@ -31,6 +32,7 @@ type Options struct {
 	PrintFlags *cmdutil.PrintFlags
 
 	NewDashboardClient func(clientID string) *dashboard.Client
+	Browser            func(string) error
 }
 
 // changeResult is the structured (-o json) payload for a successful change.
@@ -83,7 +85,7 @@ func Run(opts *Options) error {
 		user = nil
 	}
 
-	target, err := selectTarget(opts, plans)
+	target, err := selectTarget(opts, client, &token, appID, plans)
 	if err != nil {
 		return err
 	}
@@ -153,13 +155,56 @@ func Run(opts *Options) error {
 		cs.Bold(appID),
 		cs.Bold(target.Name),
 	)
-	return nil
+
+	if target.IsFree() {
+		return nil
+	}
+
+	return offerCostManagementBudget(opts, client.DashboardURL, appID)
+}
+
+// offerCostManagementBudget tells the user they can create a budget and, when
+// confirmed, opens the cost management page in the browser.
+func offerCostManagementBudget(opts *Options, dashboardURL, appID string) error {
+	if !opts.IO.CanPrompt() || !opts.IO.IsStdoutTTY() {
+		return nil
+	}
+
+	browser := opts.Browser
+	if browser == nil {
+		browser = pkgopen.Browser
+	}
+
+	cs := opts.IO.ColorScheme()
+	fmt.Fprintf(
+		opts.IO.Out,
+		"\nWant to create a budget and monitor your costs?\n",
+	)
+
+	openPage := true
+	if err := prompt.Confirm("Open cost management?", &openPage); err != nil {
+		return err
+	}
+	if !openPage {
+		return nil
+	}
+
+	url := fmt.Sprintf("%s/account/billing/cost-management?applicationId=%s", dashboardURL, appID)
+	fmt.Fprintf(opts.IO.Out, "Opening %s\n", cs.Bold(url))
+
+	return browser(url)
 }
 
 // selectTarget resolves the target plan from the --plan flag or, when
 // interactive and no flag is set, an interactive picker over the available
 // plans.
-func selectTarget(opts *Options, plans []dashboard.Plan) (*dashboard.Plan, error) {
+func selectTarget(
+	opts *Options,
+	client *dashboard.Client,
+	token *string,
+	appID string,
+	plans []dashboard.Plan,
+) (*dashboard.Plan, error) {
 	if opts.Plan != "" {
 		return resolvePlan(plans, opts.Plan)
 	}
@@ -171,7 +216,28 @@ func selectTarget(opts *Options, plans []dashboard.Plan) (*dashboard.Plan, error
 		)
 	}
 
+	cs := opts.IO.ColorScheme()
+	appLabel := cs.Bold(appID)
+	if name := currentAppName(opts, client, token, appID); name != "" {
+		appLabel = fmt.Sprintf("%s (%s)", cs.Bold(appID), name)
+	}
+	fmt.Fprintf(opts.IO.Out, "Current application: %s\n\n", appLabel)
+
 	return pickPlan(plans)
+}
+
+// currentAppName resolves the current application's display name, best-effort.
+// It returns "" when the name can't be fetched so callers fall back to the ID.
+func currentAppName(opts *Options, client *dashboard.Client, token *string, appID string) string {
+	var app *dashboard.Application
+	if err := callWithReauth(opts.IO, client, token, "Fetching application", func(t string) error {
+		var e error
+		app, e = client.GetApplication(t, appID)
+		return e
+	}); err != nil || app == nil {
+		return ""
+	}
+	return app.Name
 }
 
 // resolvePlan maps a --plan value to one of the fetched plans.

--- a/pkg/cmd/application/planchange/planchange.go
+++ b/pkg/cmd/application/planchange/planchange.go
@@ -1,0 +1,293 @@
+// Package planchange holds the logic shared by the "application upgrade" and
+// "application downgrade" commands. Both commands change the current
+// application's self-serve plan and currently behave identically, so the
+// fetch / billing-check / terms / change flow lives here once.
+package planchange
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/prompt"
+)
+
+// Options carries everything the shared plan-change flow needs. The upgrade and
+// downgrade commands populate it the same way.
+type Options struct {
+	IO     *iostreams.IOStreams
+	Config config.IConfig
+
+	Plan        string // --plan (optional): target plan, e.g. "free", "grow", "grow-plus"
+	DryRun      bool   // --dry-run: preview without calling the API
+	AcceptTerms bool   // --accept-terms: accept ToS in non-interactive mode
+
+	PrintFlags *cmdutil.PrintFlags
+
+	NewDashboardClient func(clientID string) *dashboard.Client
+}
+
+// changeResult is the structured (-o json) payload for a successful change.
+type changeResult struct {
+	ApplicationID string `json:"application_id"`
+	Plan          string `json:"plan"`
+	PlanName      string `json:"plan_name"`
+	Price         string `json:"price"`
+}
+
+// Run executes the shared plan-change flow.
+func Run(opts *Options) error {
+	cs := opts.IO.ColorScheme()
+
+	appID, err := opts.Config.Profile().GetApplicationID()
+	if err != nil {
+		return fmt.Errorf(
+			"no current application configured; configure a profile with \"algolia profile add\" or \"algolia application select\" first: %w",
+			err,
+		)
+	}
+
+	client := opts.NewDashboardClient(auth.OAuthClientID())
+
+	token, err := auth.EnsureAuthenticated(opts.IO, client)
+	if err != nil {
+		return err
+	}
+
+	var plans []dashboard.Plan
+	if err := callWithReauth(opts.IO, client, &token, "Fetching plans", func(t string) error {
+		var e error
+		plans, e = client.GetSelfServePlans(t)
+		return e
+	}); err != nil {
+		return err
+	}
+	if len(plans) == 0 {
+		return fmt.Errorf("no self-serve plans are available")
+	}
+
+	// Billing status is best-effort. If /1/user is unavailable we continue
+	// without it and let the server enforce billing validity.
+	var user *dashboard.DashboardUser
+	if err := callWithReauth(opts.IO, client, &token, "Checking account", func(t string) error {
+		var e error
+		user, e = client.GetUser(t)
+		return e
+	}); err != nil {
+		user = nil
+	}
+
+	target, err := selectTarget(opts, plans)
+	if err != nil {
+		return err
+	}
+
+	// Paid plans require a payment method that the CLI cannot collect. Only
+	// block when we positively know there is none (user fetched, flag false);
+	// otherwise defer to the server.
+	if !target.IsFree() && user != nil && !user.HasPaymentMethod {
+		return fmt.Errorf(
+			"the %q plan requires a payment method, which the CLI can't collect; add one in the Algolia dashboard (Settings → Billing) and try again",
+			target.Name,
+		)
+	}
+
+	if opts.DryRun {
+		summary := map[string]any{
+			"action":      "change_application_plan",
+			"application": appID,
+			"plan":        target.ID,
+			"dryRun":      true,
+		}
+		return cmdutil.PrintRunSummary(
+			opts.IO,
+			opts.PrintFlags,
+			summary,
+			fmt.Sprintf("Dry run: would change application %s to the %q plan", appID, target.Name),
+		)
+	}
+
+	accepted, err := confirmToS(opts, *target)
+	if err != nil {
+		return err
+	}
+	if !accepted {
+		fmt.Fprintf(
+			opts.IO.Out,
+			"%s Plan change aborted; no changes were made.\n",
+			cs.WarningIcon(),
+		)
+		return nil
+	}
+
+	if err := callWithReauth(opts.IO, client, &token, "Changing plan", func(t string) error {
+		_, e := client.ChangeApplicationPlan(t, appID, target.ID)
+		return e
+	}); err != nil {
+		return err
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, changeResult{
+			ApplicationID: appID,
+			Plan:          target.ID,
+			PlanName:      target.Name,
+			Price:         target.Price,
+		})
+	}
+
+	fmt.Fprintf(
+		opts.IO.Out,
+		"%s Application %s changed to the %s plan.\n",
+		cs.SuccessIcon(),
+		cs.Bold(appID),
+		cs.Bold(target.Name),
+	)
+	return nil
+}
+
+// selectTarget resolves the target plan from the --plan flag or, when
+// interactive and no flag is set, an interactive picker over the available
+// plans.
+func selectTarget(opts *Options, plans []dashboard.Plan) (*dashboard.Plan, error) {
+	if opts.Plan != "" {
+		return resolvePlan(plans, opts.Plan)
+	}
+
+	if !opts.IO.CanPrompt() {
+		return nil, cmdutil.FlagErrorf(
+			"--plan is required in non-interactive mode (one of: %s)",
+			strings.Join(planChoices(plans), ", "),
+		)
+	}
+
+	return pickPlan(plans)
+}
+
+// resolvePlan maps a --plan value to one of the fetched plans.
+func resolvePlan(plans []dashboard.Plan, value string) (*dashboard.Plan, error) {
+	// Exact match on the plan id (configuration.plan).
+	for i := range plans {
+		if plans[i].ID == value {
+			return &plans[i], nil
+		}
+	}
+	// The user-facing "free" choice maps to the free-type template, whose id is
+	// not fixed (it can be "build"); match on type rather than a hard-coded id.
+	if value == dashboard.PlanTypeFree {
+		for i := range plans {
+			if plans[i].IsFree() {
+				return &plans[i], nil
+			}
+		}
+	}
+	return nil, cmdutil.FlagErrorf(
+		"Invalid plan %q; valid plans: %s",
+		value,
+		strings.Join(planChoices(plans), ", "),
+	)
+}
+
+// pickPlan shows an interactive selector over the candidate plans.
+func pickPlan(candidates []dashboard.Plan) (*dashboard.Plan, error) {
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no plans are available")
+	}
+	labels := make([]string, len(candidates))
+	for i, p := range candidates {
+		labels[i] = fmt.Sprintf("%s — %s", p.Name, p.Price)
+	}
+	var selected int
+	if err := prompt.SurveyAskOne(
+		&survey.Select{
+			Message: "Select a plan:",
+			Options: labels,
+		},
+		&selected,
+	); err != nil {
+		return nil, err
+	}
+	return &candidates[selected], nil
+}
+
+// confirmToS displays the plan's terms and asks the user to accept them. The
+// prompt defaults to yes ([Y/n]). In non-interactive mode acceptance requires
+// the --accept-terms flag (chosen over silent auto-accept).
+func confirmToS(opts *Options, target dashboard.Plan) (bool, error) {
+	cs := opts.IO.ColorScheme()
+
+	terms := target.AcceptTerms
+	if terms == "" {
+		terms = fmt.Sprintf("By proceeding, you accept the Algolia %s Plan terms.", target.Name)
+	}
+	fmt.Fprintf(opts.IO.Out, "\n%s\n\n", terms)
+
+	if !opts.IO.CanPrompt() {
+		if opts.AcceptTerms {
+			fmt.Fprintf(opts.IO.Out, "%s Terms accepted via --accept-terms.\n", cs.SuccessIcon())
+			return true, nil
+		}
+		return false, cmdutil.FlagErrorf(
+			"the plan terms must be accepted in non-interactive mode; pass --accept-terms to confirm",
+		)
+	}
+
+	accepted := true
+	if err := prompt.Confirm("Do you accept these terms and want to change the plan?", &accepted); err != nil {
+		return false, err
+	}
+	return accepted, nil
+}
+
+// planChoices returns the user-facing plan identifiers (the free plan is shown
+// as "free" regardless of its underlying id).
+func planChoices(plans []dashboard.Plan) []string {
+	choices := make([]string, 0, len(plans))
+	for _, p := range plans {
+		if p.IsFree() {
+			choices = append(choices, dashboard.PlanTypeFree)
+		} else {
+			choices = append(choices, p.ID)
+		}
+	}
+	return choices
+}
+
+// callWithReauth runs fn with the current token; if it fails with a
+// session-expired error it re-authenticates once and retries, mirroring the
+// retry pattern used by the other application commands.
+func callWithReauth(
+	io *iostreams.IOStreams,
+	client *dashboard.Client,
+	token *string,
+	label string,
+	fn func(token string) error,
+) error {
+	io.StartProgressIndicatorWithLabel(label)
+	err := fn(*token)
+	io.StopProgressIndicator()
+	if err == nil {
+		return nil
+	}
+
+	newToken, reAuthErr := auth.ReauthenticateIfExpired(io, client, err)
+	if reAuthErr != nil {
+		return reAuthErr
+	}
+	*token = newToken
+
+	io.StartProgressIndicatorWithLabel(label)
+	err = fn(*token)
+	io.StopProgressIndicator()
+	return err
+}

--- a/pkg/cmd/application/planchange/planchange_test.go
+++ b/pkg/cmd/application/planchange/planchange_test.go
@@ -105,6 +105,17 @@ func newServer(t *testing.T, userJSON string) *planChangeServer {
 		}
 		_, _ = w.Write([]byte(userJSON))
 	})
+	mux.HandleFunc("/1/application/APP1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(dashboard.SingleApplicationResponse{
+			Data: dashboard.ApplicationResource{
+				ID: "APP1", Type: "application",
+				Attributes: dashboard.ApplicationAttributes{
+					ApplicationID: "APP1",
+					Name:          "My App",
+				},
+			},
+		}))
+	})
 	mux.HandleFunc(
 		"/1/applications/APP1/plan/self-serve",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -139,12 +150,13 @@ func newOpts(
 	t *testing.T,
 	srv *planChangeServer,
 	isTTY bool,
-) (*Options, *test.CmdInOut) {
+) (*Options, *test.CmdInOut, *string) {
 	t.Helper()
 	seedToken(t)
 	t.Setenv("ALGOLIA_APPLICATION_ID", "APP1")
 
 	f, out := test.NewFactory(isTTY, nil, nil, "")
+	opened := new(string)
 	opts := &Options{
 		IO:         f.IOStreams,
 		Config:     f.Config,
@@ -152,17 +164,22 @@ func newOpts(
 		NewDashboardClient: func(string) *dashboard.Client {
 			c := dashboard.NewClientWithHTTPClient("test", srv.Client())
 			c.APIURL = srv.URL
+			c.DashboardURL = "https://dashboard.algolia.com"
 			return c
 		},
+		Browser: func(url string) error {
+			*opened = url
+			return nil
+		},
 	}
-	return opts, out
+	return opts, out, opened
 }
 
 func TestRun_WithPlanFlag(t *testing.T) {
 	srv := newServer(t, `{"has_payment_method": true}`)
 	defer srv.Close()
 
-	opts, out := newOpts(t, srv, false)
+	opts, out, _ := newOpts(t, srv, false)
 	opts.Plan = "grow"
 	opts.AcceptTerms = true
 
@@ -177,7 +194,7 @@ func TestRun_FreeTargetNotBilled(t *testing.T) {
 	srv := newServer(t, `{"has_payment_method": false}`)
 	defer srv.Close()
 
-	opts, out := newOpts(t, srv, false)
+	opts, out, _ := newOpts(t, srv, false)
 	opts.Plan = "free"
 	opts.AcceptTerms = true
 
@@ -192,7 +209,7 @@ func TestRun_BillingBlock(t *testing.T) {
 	srv := newServer(t, `{"has_payment_method": false}`)
 	defer srv.Close()
 
-	opts, _ := newOpts(t, srv, false)
+	opts, _, _ := newOpts(t, srv, false)
 	opts.Plan = "grow"
 	opts.AcceptTerms = true
 
@@ -208,7 +225,7 @@ func TestRun_ToSDeclineAborts(t *testing.T) {
 
 	defer prompt.StubConfirm(false)()
 
-	opts, out := newOpts(t, srv, true)
+	opts, out, _ := newOpts(t, srv, true)
 	opts.Plan = "grow"
 
 	require.NoError(t, Run(opts))
@@ -220,7 +237,7 @@ func TestRun_NonInteractiveRequiresPlan(t *testing.T) {
 	srv := newServer(t, `{"has_payment_method": true}`)
 	defer srv.Close()
 
-	opts, _ := newOpts(t, srv, false)
+	opts, _, _ := newOpts(t, srv, false)
 	// No --plan and no TTY.
 
 	err := Run(opts)
@@ -242,18 +259,19 @@ func TestRun_InteractivePicker(t *testing.T) {
 	t.Cleanup(func() { prompt.SurveyAskOne = origAsk })
 	defer prompt.StubConfirm(true)()
 
-	opts, _ := newOpts(t, srv, true)
+	opts, out, _ := newOpts(t, srv, true)
 
 	require.NoError(t, Run(opts))
 	assert.Equal(t, 1, srv.patchCalls)
 	assert.Equal(t, "grow", srv.lastPlan)
+	assert.Contains(t, out.String(), "Current application: APP1 (My App)")
 }
 
 func TestRun_DryRunDoesNotCallAPI(t *testing.T) {
 	srv := newServer(t, `{"has_payment_method": true}`)
 	defer srv.Close()
 
-	opts, out := newOpts(t, srv, false)
+	opts, out, _ := newOpts(t, srv, false)
 	opts.Plan = "grow"
 	opts.DryRun = true
 
@@ -263,11 +281,46 @@ func TestRun_DryRunDoesNotCallAPI(t *testing.T) {
 	assert.Contains(t, out.String(), "Grow")
 }
 
+func TestRun_OfferCostManagementBudget(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": true}`)
+	defer srv.Close()
+
+	defer prompt.StubConfirm(true)()
+
+	opts, out, opened := newOpts(t, srv, true)
+	opts.Plan = "grow"
+
+	require.NoError(t, Run(opts))
+	assert.Equal(t, 1, srv.patchCalls)
+	assert.Contains(t, out.String(), "create a budget")
+	assert.Equal(
+		t,
+		"https://dashboard.algolia.com/account/billing/cost-management?applicationId=APP1",
+		*opened,
+	)
+}
+
+func TestRun_FreePlanSkipsCostManagementBudget(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	defer prompt.StubConfirm(true)()
+
+	opts, out, opened := newOpts(t, srv, true)
+	opts.Plan = "free"
+	opts.AcceptTerms = true
+
+	require.NoError(t, Run(opts))
+	assert.Equal(t, 1, srv.patchCalls)
+	assert.NotContains(t, out.String(), "create a budget")
+	assert.Empty(t, *opened)
+}
+
 func TestRun_OutputJSON(t *testing.T) {
 	srv := newServer(t, `{"has_payment_method": true}`)
 	defer srv.Close()
 
-	opts, out := newOpts(t, srv, false)
+	opts, out, _ := newOpts(t, srv, false)
 	opts.Plan = "grow"
 	opts.AcceptTerms = true
 	opts.PrintFlags = newPrintFlags("json")

--- a/pkg/cmd/application/planchange/planchange_test.go
+++ b/pkg/cmd/application/planchange/planchange_test.go
@@ -1,0 +1,279 @@
+package planchange
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/prompt"
+	"github.com/algolia/cli/test"
+)
+
+// seedToken installs an in-memory keyring with a valid token so
+// auth.EnsureAuthenticated short-circuits without hitting the network.
+func seedToken(t *testing.T) {
+	t.Helper()
+	keyring.MockInit()
+	require.NoError(t, auth.SaveToken(&dashboard.OAuthTokenResponse{
+		AccessToken: "test-token",
+		ExpiresIn:   3600,
+		CreatedAt:   time.Now().Unix(),
+	}))
+}
+
+func samplePlanTemplates() []dashboard.PlanTemplateResource {
+	return []dashboard.PlanTemplateResource{
+		{
+			ID:   "build",
+			Type: "plan_template",
+			Attributes: dashboard.PlanTemplateAttributes{
+				Name:        "Build",
+				Description: "Free forever Search & Discovery API.",
+				Type:        "free",
+				Configuration: dashboard.PlanTemplateConfiguration{
+					Plan:        "build",
+					AcceptTerms: "Build terms",
+				},
+			},
+		},
+		{
+			ID:   "grow",
+			Type: "plan_template",
+			Attributes: dashboard.PlanTemplateAttributes{
+				Name:        "Grow",
+				Description: "Best-in-class Search & Discovery API.",
+				Type:        "freeform",
+				Freeform:    "$0.50 / 1,000 Requests",
+				Configuration: dashboard.PlanTemplateConfiguration{
+					Plan:        "grow",
+					AcceptTerms: "Grow terms",
+				},
+			},
+		},
+		{
+			ID:   "grow-plus",
+			Type: "plan_template",
+			Attributes: dashboard.PlanTemplateAttributes{
+				Name:        "Grow Plus",
+				Description: "AI-powered Search & Discovery API.",
+				Type:        "freeform",
+				Freeform:    "$1.75 / 1,000 Requests",
+				Configuration: dashboard.PlanTemplateConfiguration{
+					Plan:        "grow-plus",
+					AcceptTerms: "Grow Plus terms",
+				},
+			},
+		},
+	}
+}
+
+type planChangeServer struct {
+	*httptest.Server
+	patchCalls int
+	lastPlan   string
+}
+
+// newServer spins up a dashboard stub. userJSON is the raw GET /1/user body;
+// an empty string makes /1/user fail so the "user unavailable" fallback is used.
+func newServer(t *testing.T, userJSON string) *planChangeServer {
+	t.Helper()
+	srv := &planChangeServer{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/1/plan-templates/self-serve",
+		func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(dashboard.PlanTemplatesResponse{
+				Data: samplePlanTemplates(),
+			}))
+		},
+	)
+	mux.HandleFunc("/1/user", func(w http.ResponseWriter, _ *http.Request) {
+		if userJSON == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(userJSON))
+	})
+	mux.HandleFunc(
+		"/1/applications/APP1/plan/self-serve",
+		func(w http.ResponseWriter, r *http.Request) {
+			srv.patchCalls++
+			var payload dashboard.ChangePlanRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+			srv.lastPlan = payload.Plan
+			require.NoError(t, json.NewEncoder(w).Encode(dashboard.SingleApplicationResponse{
+				Data: dashboard.ApplicationResource{
+					ID: "APP1", Type: "application",
+					Attributes: dashboard.ApplicationAttributes{
+						ApplicationID: "APP1",
+						Name:          "My App",
+					},
+				},
+			}))
+		},
+	)
+
+	srv.Server = httptest.NewServer(mux)
+	return srv
+}
+
+func newPrintFlags(output string) *cmdutil.PrintFlags {
+	pf := cmdutil.NewPrintFlags()
+	*pf.OutputFormat = output
+	pf.OutputFlagSpecified = func() bool { return output != "" }
+	return pf
+}
+
+func newOpts(
+	t *testing.T,
+	srv *planChangeServer,
+	isTTY bool,
+) (*Options, *test.CmdInOut) {
+	t.Helper()
+	seedToken(t)
+	t.Setenv("ALGOLIA_APPLICATION_ID", "APP1")
+
+	f, out := test.NewFactory(isTTY, nil, nil, "")
+	opts := &Options{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		PrintFlags: newPrintFlags(""),
+		NewDashboardClient: func(string) *dashboard.Client {
+			c := dashboard.NewClientWithHTTPClient("test", srv.Client())
+			c.APIURL = srv.URL
+			return c
+		},
+	}
+	return opts, out
+}
+
+func TestRun_WithPlanFlag(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": true}`)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, false)
+	opts.Plan = "grow"
+	opts.AcceptTerms = true
+
+	require.NoError(t, Run(opts))
+	assert.Equal(t, 1, srv.patchCalls)
+	assert.Equal(t, "grow", srv.lastPlan)
+	assert.Contains(t, out.String(), "Grow")
+}
+
+func TestRun_FreeTargetNotBilled(t *testing.T) {
+	// No payment method, but the free target must not be blocked.
+	srv := newServer(t, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, false)
+	opts.Plan = "free"
+	opts.AcceptTerms = true
+
+	require.NoError(t, Run(opts))
+	assert.Equal(t, 1, srv.patchCalls)
+	// "free" maps to the free-type template, whose id is "build".
+	assert.Equal(t, "build", srv.lastPlan)
+	assert.Contains(t, out.String(), "Build")
+}
+
+func TestRun_BillingBlock(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	opts, _ := newOpts(t, srv, false)
+	opts.Plan = "grow"
+	opts.AcceptTerms = true
+
+	err := Run(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "payment method")
+	assert.Equal(t, 0, srv.patchCalls)
+}
+
+func TestRun_ToSDeclineAborts(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": true}`)
+	defer srv.Close()
+
+	defer prompt.StubConfirm(false)()
+
+	opts, out := newOpts(t, srv, true)
+	opts.Plan = "grow"
+
+	require.NoError(t, Run(opts))
+	assert.Equal(t, 0, srv.patchCalls)
+	assert.Contains(t, out.String(), "aborted")
+}
+
+func TestRun_NonInteractiveRequiresPlan(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": true}`)
+	defer srv.Close()
+
+	opts, _ := newOpts(t, srv, false)
+	// No --plan and no TTY.
+
+	err := Run(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--plan is required")
+	assert.Equal(t, 0, srv.patchCalls)
+}
+
+func TestRun_InteractivePicker(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": true}`)
+	defer srv.Close()
+
+	// Pick the second candidate (grow); the picker lists all plans in order.
+	origAsk := prompt.SurveyAskOne
+	prompt.SurveyAskOne = func(_ survey.Prompt, response interface{}, _ ...survey.AskOpt) error {
+		*(response.(*int)) = 1
+		return nil
+	}
+	t.Cleanup(func() { prompt.SurveyAskOne = origAsk })
+	defer prompt.StubConfirm(true)()
+
+	opts, _ := newOpts(t, srv, true)
+
+	require.NoError(t, Run(opts))
+	assert.Equal(t, 1, srv.patchCalls)
+	assert.Equal(t, "grow", srv.lastPlan)
+}
+
+func TestRun_DryRunDoesNotCallAPI(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": true}`)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, false)
+	opts.Plan = "grow"
+	opts.DryRun = true
+
+	require.NoError(t, Run(opts))
+	assert.Equal(t, 0, srv.patchCalls)
+	assert.Contains(t, out.String(), "Dry run")
+	assert.Contains(t, out.String(), "Grow")
+}
+
+func TestRun_OutputJSON(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": true}`)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, false)
+	opts.Plan = "grow"
+	opts.AcceptTerms = true
+	opts.PrintFlags = newPrintFlags("json")
+
+	require.NoError(t, Run(opts))
+	assert.Equal(t, 1, srv.patchCalls)
+	assert.Contains(t, out.String(), `"plan":"grow"`)
+	assert.Contains(t, out.String(), `"application_id":"APP1"`)
+}

--- a/pkg/cmd/application/planchange/planchange_test.go
+++ b/pkg/cmd/application/planchange/planchange_test.go
@@ -103,7 +103,7 @@ func newServer(t *testing.T, userJSON string) *planChangeServer {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		_, _ = w.Write([]byte(userJSON))
+		require.NoError(t, json.NewEncoder(w).Encode(json.RawMessage(userJSON)))
 	})
 	mux.HandleFunc("/1/application/APP1", func(w http.ResponseWriter, _ *http.Request) {
 		require.NoError(t, json.NewEncoder(w).Encode(dashboard.SingleApplicationResponse{

--- a/pkg/cmd/application/plans/plans.go
+++ b/pkg/cmd/application/plans/plans.go
@@ -1,0 +1,111 @@
+package plans
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+type PlansOptions struct {
+	IO     *iostreams.IOStreams
+	Config config.IConfig
+
+	PrintFlags *cmdutil.PrintFlags
+
+	NewDashboardClient func(clientID string) *dashboard.Client
+}
+
+func NewPlansCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &PlansOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		PrintFlags: cmdutil.NewPrintFlags(),
+		NewDashboardClient: func(clientID string) *dashboard.Client {
+			return dashboard.NewClient(clientID)
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "plans",
+		Short: "List the available self-serve plans",
+		Long: heredoc.Doc(`
+			List the self-serve plans you can switch to with "algolia application upgrade"
+			or "algolia application downgrade", along with their pricing.
+		`),
+		Example: heredoc.Doc(`
+			# List the available plans
+			$ algolia application plans
+
+			# Output as JSON
+			$ algolia application plans --output json
+		`),
+		Args: validators.NoArgs(),
+		Annotations: map[string]string{
+			"skipAuthCheck": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPlansCmd(opts)
+		},
+	}
+
+	opts.PrintFlags.AddFlags(cmd)
+
+	return cmd
+}
+
+func runPlansCmd(opts *PlansOptions) error {
+	cs := opts.IO.ColorScheme()
+
+	client := opts.NewDashboardClient(auth.OAuthClientID())
+
+	accessToken, err := auth.EnsureAuthenticated(opts.IO, client)
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Fetching plans")
+	plans, err := client.GetSelfServePlans(accessToken)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		newToken, reAuthErr := auth.ReauthenticateIfExpired(opts.IO, client, err)
+		if reAuthErr != nil {
+			return reAuthErr
+		}
+		accessToken = newToken
+		opts.IO.StartProgressIndicatorWithLabel("Fetching plans")
+		plans, err = client.GetSelfServePlans(accessToken)
+		opts.IO.StopProgressIndicator()
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, plans)
+	}
+
+	if len(plans) == 0 {
+		fmt.Fprintf(opts.IO.Out, "%s No plans available.\n", cs.WarningIcon())
+		return nil
+	}
+
+	for _, plan := range plans {
+		fmt.Fprintf(opts.IO.Out, "%s  %s\n", cs.Bold(plan.Name), plan.Price)
+		if plan.Description != "" {
+			fmt.Fprintf(opts.IO.Out, "  %s\n", plan.Description)
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/application/plans/plans_test.go
+++ b/pkg/cmd/application/plans/plans_test.go
@@ -1,0 +1,118 @@
+package plans
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/test"
+)
+
+func seedToken(t *testing.T) {
+	t.Helper()
+	keyring.MockInit()
+	require.NoError(t, auth.SaveToken(&dashboard.OAuthTokenResponse{
+		AccessToken: "test-token",
+		ExpiresIn:   3600,
+		CreatedAt:   time.Now().Unix(),
+	}))
+}
+
+func newServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/1/plan-templates/self-serve",
+		func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(dashboard.PlanTemplatesResponse{
+				Data: []dashboard.PlanTemplateResource{
+					{
+						ID:   "build",
+						Type: "plan_template",
+						Attributes: dashboard.PlanTemplateAttributes{
+							Name:          "Build",
+							Description:   "Free forever Search & Discovery API.",
+							Type:          "free",
+							Configuration: dashboard.PlanTemplateConfiguration{Plan: "build"},
+						},
+					},
+					{
+						ID:   "grow",
+						Type: "plan_template",
+						Attributes: dashboard.PlanTemplateAttributes{
+							Name:          "Grow",
+							Description:   "Best-in-class Search & Discovery API.",
+							Type:          "freeform",
+							Freeform:      "$0.50 / 1,000 Requests",
+							Configuration: dashboard.PlanTemplateConfiguration{Plan: "grow"},
+						},
+					},
+				},
+			}))
+		},
+	)
+	return httptest.NewServer(mux)
+}
+
+func newOpts(
+	t *testing.T,
+	srv *httptest.Server,
+	isTTY bool,
+	output string,
+) (*PlansOptions, *test.CmdInOut) {
+	t.Helper()
+	seedToken(t)
+
+	f, out := test.NewFactory(isTTY, nil, nil, "")
+	pf := cmdutil.NewPrintFlags()
+	*pf.OutputFormat = output
+	pf.OutputFlagSpecified = func() bool { return output != "" }
+
+	opts := &PlansOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		PrintFlags: pf,
+		NewDashboardClient: func(string) *dashboard.Client {
+			c := dashboard.NewClientWithHTTPClient("test", srv.Client())
+			c.APIURL = srv.URL
+			return c
+		},
+	}
+	return opts, out
+}
+
+func Test_runPlansCmd(t *testing.T) {
+	srv := newServer(t)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, true, "")
+	require.NoError(t, runPlansCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, "Build")
+	assert.Contains(t, got, "Free")
+	assert.Contains(t, got, "Grow")
+	assert.Contains(t, got, "$0.50 / 1,000 Requests")
+}
+
+func Test_runPlansCmd_outputJSON(t *testing.T) {
+	srv := newServer(t)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, false, "json")
+	require.NoError(t, runPlansCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, `"name":"Build"`)
+	assert.Contains(t, got, `"price":"Free"`)
+	assert.Contains(t, got, `"name":"Grow"`)
+}

--- a/pkg/cmd/application/update/update.go
+++ b/pkg/cmd/application/update/update.go
@@ -1,0 +1,117 @@
+package update
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+type UpdateOptions struct {
+	IO     *iostreams.IOStreams
+	Config config.IConfig
+
+	Name string
+
+	PrintFlags *cmdutil.PrintFlags
+
+	NewDashboardClient func(clientID string) *dashboard.Client
+}
+
+func NewUpdateCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &UpdateOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		PrintFlags: cmdutil.NewPrintFlags(),
+		NewDashboardClient: func(clientID string) *dashboard.Client {
+			return dashboard.NewClient(clientID)
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Rename the current Algolia application",
+		Long: heredoc.Doc(`
+			Rename the application associated with the current CLI profile.
+			Requires an active application to be selected (run "algolia application select" first).
+		`),
+		Example: heredoc.Doc(`
+			# Rename the current application
+			$ algolia application update --name "New Name"
+		`),
+		Args: validators.NoArgs(),
+		Annotations: map[string]string{
+			"skipAuthCheck": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUpdateCmd(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Name, "name", "", "New name for the current application")
+	_ = cmd.MarkFlagRequired("name")
+
+	opts.PrintFlags.AddFlags(cmd)
+
+	return cmd
+}
+
+func runUpdateCmd(opts *UpdateOptions) error {
+	cs := opts.IO.ColorScheme()
+
+	appID, err := opts.Config.Profile().GetApplicationID()
+	if err != nil {
+		return fmt.Errorf(
+			"no current application configured; configure a profile with \"algolia profile add\" or \"algolia application select\" first: %w",
+			err,
+		)
+	}
+
+	client := opts.NewDashboardClient(auth.OAuthClientID())
+
+	accessToken, err := auth.EnsureAuthenticated(opts.IO, client)
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicatorWithLabel("Updating application")
+	app, err := client.UpdateApplication(accessToken, appID, opts.Name)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		newToken, reAuthErr := auth.ReauthenticateIfExpired(opts.IO, client, err)
+		if reAuthErr != nil {
+			return reAuthErr
+		}
+		accessToken = newToken
+		opts.IO.StartProgressIndicatorWithLabel("Updating application")
+		app, err = client.UpdateApplication(accessToken, appID, opts.Name)
+		opts.IO.StopProgressIndicator()
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, app)
+	}
+
+	fmt.Fprintf(
+		opts.IO.Out,
+		"%s Application %s renamed to %q.\n",
+		cs.SuccessIcon(),
+		cs.Bold(app.ID),
+		app.Name,
+	)
+	return nil
+}

--- a/pkg/cmd/application/update/update_test.go
+++ b/pkg/cmd/application/update/update_test.go
@@ -1,0 +1,115 @@
+package update
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/test"
+)
+
+func seedToken(t *testing.T) {
+	t.Helper()
+	keyring.MockInit()
+	require.NoError(t, auth.SaveToken(&dashboard.OAuthTokenResponse{
+		AccessToken: "test-token",
+		ExpiresIn:   3600,
+		CreatedAt:   time.Now().Unix(),
+	}))
+}
+
+// newServer stubs the dashboard PATCH endpoint, echoing the requested name back
+// in the response so the command's success output can be asserted.
+func newServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/applications/APP1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		var payload dashboard.UpdateApplicationRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		require.NoError(t, json.NewEncoder(w).Encode(dashboard.SingleApplicationResponse{
+			Data: dashboard.ApplicationResource{
+				ID:   "APP1",
+				Type: "application",
+				Attributes: dashboard.ApplicationAttributes{
+					ApplicationID: "APP1",
+					Name:          payload.Name,
+				},
+			},
+		}))
+	})
+	return httptest.NewServer(mux)
+}
+
+func newOpts(
+	t *testing.T,
+	srv *httptest.Server,
+	isTTY bool,
+	output string,
+) (*UpdateOptions, *test.CmdInOut) {
+	t.Helper()
+	seedToken(t)
+	t.Setenv("ALGOLIA_APPLICATION_ID", "APP1")
+
+	f, out := test.NewFactory(isTTY, nil, nil, "")
+	pf := cmdutil.NewPrintFlags()
+	*pf.OutputFormat = output
+	pf.OutputFlagSpecified = func() bool { return output != "" }
+
+	opts := &UpdateOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		PrintFlags: pf,
+		Name:       "Renamed App",
+		NewDashboardClient: func(string) *dashboard.Client {
+			c := dashboard.NewClientWithHTTPClient("test", srv.Client())
+			c.APIURL = srv.URL
+			return c
+		},
+	}
+	return opts, out
+}
+
+func Test_runUpdateCmd(t *testing.T) {
+	srv := newServer(t)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, true, "")
+	require.NoError(t, runUpdateCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, "APP1")
+	assert.Contains(t, got, "Renamed App")
+}
+
+func Test_runUpdateCmd_outputJSON(t *testing.T) {
+	srv := newServer(t)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, false, "json")
+	require.NoError(t, runUpdateCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, `"id":"APP1"`)
+	assert.Contains(t, got, `"name":"Renamed App"`)
+}
+
+func TestNewUpdateCmd(t *testing.T) {
+	f, _ := test.NewFactory(false, nil, nil, "")
+	cmd := NewUpdateCmd(f)
+
+	assert.Equal(t, "update", cmd.Name())
+	assert.Equal(t, "true", cmd.Annotations["skipAuthCheck"])
+
+	nameFlag := cmd.Flags().Lookup("name")
+	require.NotNil(t, nameFlag)
+}

--- a/pkg/cmd/application/upgrade/upgrade.go
+++ b/pkg/cmd/application/upgrade/upgrade.go
@@ -1,0 +1,65 @@
+package upgrade
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/cmd/application/planchange"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+func NewUpgradeCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &planchange.Options{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		PrintFlags: cmdutil.NewPrintFlags(),
+		NewDashboardClient: func(clientID string) *dashboard.Client {
+			return dashboard.NewClient(clientID)
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade the current application to a higher-tier plan",
+		Long: heredoc.Doc(`
+			Change the application associated with the current CLI profile to a
+			higher-tier self-serve plan.
+
+			Paid plans require a payment method on your account; the CLI can't
+			collect card details, so add one in the Algolia dashboard first.
+			You must accept the plan's terms of service before the change is applied.
+		`),
+		Example: heredoc.Doc(`
+			# Pick a higher-tier plan interactively
+			$ algolia application upgrade
+
+			# Upgrade to a specific plan
+			$ algolia application upgrade --plan grow
+
+			# Non-interactive (accept terms up front)
+			$ algolia application upgrade --plan grow-plus --accept-terms
+
+			# Preview the change without applying it
+			$ algolia application upgrade --plan grow --dry-run
+		`),
+		Args: validators.NoArgs(),
+		Annotations: map[string]string{
+			"skipAuthCheck": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return planchange.Run(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Plan, "plan", "", "Target plan (free, grow, grow-plus)")
+	cmd.Flags().
+		BoolVar(&opts.DryRun, "dry-run", false, "Preview the plan change without applying it")
+	cmd.Flags().
+		BoolVarP(&opts.AcceptTerms, "accept-terms", "y", false, "Accept the plan terms of service (required in non-interactive mode)")
+
+	opts.PrintFlags.AddFlags(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/application/upgrade/upgrade_test.go
+++ b/pkg/cmd/application/upgrade/upgrade_test.go
@@ -1,0 +1,25 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/test"
+)
+
+func TestNewUpgradeCmd(t *testing.T) {
+	f, _ := test.NewFactory(false, nil, nil, "")
+	cmd := NewUpgradeCmd(f)
+
+	assert.Equal(t, "upgrade", cmd.Name())
+	assert.Equal(t, "true", cmd.Annotations["skipAuthCheck"])
+
+	require.NotNil(t, cmd.Flags().Lookup("plan"))
+	require.NotNil(t, cmd.Flags().Lookup("dry-run"))
+
+	acceptTerms := cmd.Flags().Lookup("accept-terms")
+	require.NotNil(t, acceptTerms)
+	assert.Equal(t, "y", acceptTerms.Shorthand)
+}

--- a/pkg/cmd/open/open.go
+++ b/pkg/cmd/open/open.go
@@ -54,14 +54,15 @@ type dashboardTarget struct {
 }
 
 var dashboardTargets = map[string]dashboardTarget{
-	"dashboard":  {path: "dashboard"},
-	"indices":    {path: "explorer/browse"},
-	"crawler":    {path: "crawler"},
-	"connectors": {path: "connectors"},
-	"api-keys":   {path: "account/api-keys/all", accountScoped: true},
-	"usage":      {path: "account/billing/usage", accountScoped: true},
-	"team":       {path: "account/teams", accountScoped: true},
-	"billing":    {path: "account/billing/details", accountScoped: true},
+	"dashboard":       {path: "dashboard"},
+	"indices":         {path: "explorer/browse"},
+	"crawler":         {path: "crawler"},
+	"connectors":      {path: "connectors"},
+	"api-keys":        {path: "account/api-keys/all", accountScoped: true},
+	"usage":           {path: "account/billing/usage", accountScoped: true},
+	"team":            {path: "account/teams", accountScoped: true},
+	"billing":         {path: "account/billing/details", accountScoped: true},
+	"cost-management": {path: "account/billing/cost-management", accountScoped: true},
 }
 
 // targetNames returns every supported shortcut, sorted.
@@ -140,9 +141,9 @@ func NewOpenCmd(f *cmdutil.Factory) *cobra.Command {
 			Resource shortcuts (docs, API reference, status, …) open directly.
 
 			Application pages (dashboard, indices, crawler, connectors, api-keys,
-			usage, team, billing) are scoped to the current application: they
-			require you to be signed in, and prompt you to select an application
-			if none is configured.
+			usage, team, billing, cost-management) are scoped to the current
+			application: they require you to be signed in and prompt you to select
+			an application if none is configured.
 
 			Run 'algolia open --list' to see every shortcut.
 

--- a/pkg/cmd/open/open_test.go
+++ b/pkg/cmd/open/open_test.go
@@ -29,6 +29,7 @@ func TestDashboardURL(t *testing.T) {
 		{"usage", "https://dashboard.algolia.com/account/billing/usage?applicationId=APP123"},
 		{"team", "https://dashboard.algolia.com/account/teams?applicationId=APP123"},
 		{"billing", "https://dashboard.algolia.com/account/billing/details?applicationId=APP123"},
+		{"cost-management", "https://dashboard.algolia.com/account/billing/cost-management?applicationId=APP123"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What
- **`application update --name`** — rename the current application
- **`application plans`** — list available self-serve plans (supports `-o json`)
- **`application upgrade` / `application downgrade`** — change the current app's self-serve plan
  - interactive picker or `--plan`, plus `--dry-run` and `--accept-terms`
  - both share one `planchange` flow and currently behave identically (no tier/direction enforcement)
  - blocks paid plans when the account has no payment method; requires ToS acceptance before applying
- **Dashboard client**: add `UpdateApplication`, `GetSelfServePlans`, `GetUser`, `ChangeApplicationPlan` (+ types), reusing the existing OAuth reauth-on-expiry flow
- **Budget**: Offer to control the cost by redirect to the cost-management page after upgrading to a paid plan

## Test
- [ ] Manual: `application update --name`, `application plans`, `application upgrade --dry-run`, interactive `upgrade`/`downgrade`
- [ ] When upgrading your app to a paid plan, you should see "Want to create a budget and monitor your costs?"
	- [ ] Pressing Y or Enter should open a browser page to the cost-management page of your current application

<img width="943" height="217" alt="Screenshot 2026-06-01 at 14 10 14" src="https://github.com/user-attachments/assets/da4be481-8b7e-48fe-8b57-96f27a697149" />


## Dependencies

~https://github.com/algolia/AlgoliaWeb/pull/28576 --> needs to be live~ Live ✅ 


[GROUT-304]

[GROUT-304]: https://algolia.atlassian.net/browse/GROUT-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ