### PR TITLE
feat(config): add state.toml store

### DIFF
--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/algolia/cli/pkg/utils"
+)
+
+// ApplicationState holds the non-secret, per-application data persisted in
+// state.toml. Secrets (API keys) live in the OS keychain, not here.
+type ApplicationState struct {
+	APIKeyUUID string `toml:"api_key_uuid"`
+	Alias      string `toml:"alias"`
+}
+
+// State is the in-memory representation of state.toml, the new source of truth
+// for non-secret CLI configuration.
+type State struct {
+	CurrentApplicationID string                      `toml:"current_application_id"`
+	Applications         map[string]ApplicationState `toml:"applications"`
+}
+
+// LoadState reads state.toml from path. A missing file is not an error: it
+// returns an empty, ready-to-use State.
+func LoadState(path string) (*State, error) {
+	state := &State{Applications: map[string]ApplicationState{}}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return state, nil
+	}
+
+	if _, err := toml.DecodeFile(path, state); err != nil {
+		return nil, err
+	}
+
+	if state.Applications == nil {
+		state.Applications = map[string]ApplicationState{}
+	}
+
+	return state, nil
+}
+
+// Save writes the State to path atomically: it encodes to a temporary file in
+// the same directory, then renames it over the target so a crash mid-write can
+// never leave a half-written state.toml.
+func (s *State) Save(path string) error {
+	if err := utils.MakePath(path); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".state-*.toml")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename below succeeds
+
+	if err := toml.NewEncoder(tmp).Encode(s); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, path)
+}

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -70,3 +70,16 @@ func (s *State) Save(path string) error {
 
 	return os.Rename(tmpName, path)
 }
+
+// SetCurrentApplication records appID as the currently selected application.
+func (s *State) SetCurrentApplication(appID string) {
+	s.CurrentApplicationID = appID
+}
+
+// UpsertApplication inserts or replaces the state for a given application ID.
+func (s *State) UpsertApplication(appID string, app ApplicationState) {
+	if s.Applications == nil {
+		s.Applications = map[string]ApplicationState{}
+	}
+	s.Applications[appID] = app
+}

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -83,3 +83,14 @@ func (s *State) UpsertApplication(appID string, app ApplicationState) {
 	}
 	s.Applications[appID] = app
 }
+
+// ApplicationByAlias returns the application ID whose entry carries the given
+// alias, and whether such an entry was found.
+func (s *State) ApplicationByAlias(alias string) (string, bool) {
+	for appID, app := range s.Applications {
+		if app.Alias == alias {
+			return appID, true
+		}
+	}
+	return "", false
+}

--- a/pkg/config/state_test.go
+++ b/pkg/config/state_test.go
@@ -35,3 +35,23 @@ func TestState_SaveAndLoadRoundTrip(t *testing.T) {
 	assert.Equal(t, "uuid-1", loaded.Applications["APP1"].APIKeyUUID)
 	assert.Equal(t, "prod", loaded.Applications["APP1"].Alias)
 }
+
+func TestState_MutatorsPersist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.toml")
+
+	state := &State{}
+	state.UpsertApplication("APP1", ApplicationState{APIKeyUUID: "uuid-1", Alias: "prod"})
+	state.SetCurrentApplication("APP1")
+	require.NoError(t, state.Save(path))
+
+	loaded, err := LoadState(path)
+	require.NoError(t, err)
+	assert.Equal(t, "APP1", loaded.CurrentApplicationID)
+	assert.Equal(t, "prod", loaded.Applications["APP1"].Alias)
+
+	// Upsert replaces an existing entry rather than duplicating it.
+	loaded.UpsertApplication("APP1", ApplicationState{APIKeyUUID: "uuid-2", Alias: "staging"})
+	assert.Len(t, loaded.Applications, 1)
+	assert.Equal(t, "uuid-2", loaded.Applications["APP1"].APIKeyUUID)
+	assert.Equal(t, "staging", loaded.Applications["APP1"].Alias)
+}

--- a/pkg/config/state_test.go
+++ b/pkg/config/state_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -70,4 +71,13 @@ func TestState_ApplicationByAlias(t *testing.T) {
 
 	_, found = state.ApplicationByAlias("missing")
 	assert.False(t, found)
+}
+
+func TestState_LoadCorruptFileReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`key = "unterminated`), 0o600))
+
+	state, err := LoadState(path)
+	require.Error(t, err)
+	assert.Nil(t, state)
 }

--- a/pkg/config/state_test.go
+++ b/pkg/config/state_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestState_LoadMissingFileReturnsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.toml")
+
+	state, err := LoadState(path)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Empty(t, state.CurrentApplicationID)
+	assert.Empty(t, state.Applications)
+}
+
+func TestState_SaveAndLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.toml")
+
+	state := &State{
+		CurrentApplicationID: "APP1",
+		Applications: map[string]ApplicationState{
+			"APP1": {APIKeyUUID: "uuid-1", Alias: "prod"},
+		},
+	}
+	require.NoError(t, state.Save(path))
+
+	loaded, err := LoadState(path)
+	require.NoError(t, err)
+	assert.Equal(t, "APP1", loaded.CurrentApplicationID)
+	assert.Equal(t, "uuid-1", loaded.Applications["APP1"].APIKeyUUID)
+	assert.Equal(t, "prod", loaded.Applications["APP1"].Alias)
+}

--- a/pkg/config/state_test.go
+++ b/pkg/config/state_test.go
@@ -55,3 +55,19 @@ func TestState_MutatorsPersist(t *testing.T) {
 	assert.Equal(t, "uuid-2", loaded.Applications["APP1"].APIKeyUUID)
 	assert.Equal(t, "staging", loaded.Applications["APP1"].Alias)
 }
+
+func TestState_ApplicationByAlias(t *testing.T) {
+	state := &State{
+		Applications: map[string]ApplicationState{
+			"APP1": {Alias: "prod"},
+			"APP2": {Alias: "staging"},
+		},
+	}
+
+	appID, found := state.ApplicationByAlias("staging")
+	assert.True(t, found)
+	assert.Equal(t, "APP2", appID)
+
+	_, found = state.ApplicationByAlias("missing")
+	assert.False(t, found)
+}


### PR DESCRIPTION
## What

- Adds a self-contained `state.toml` store in `pkg/config`: load, atomic save (temp file + rename), mutators, and alias lookup.
- Purely additive, no callers yet, so no behaviour change.

## Test

Unit tests only (no CLI surface yet):

```sh
go test ./pkg/config -run TestState -v
```

[GROUT-305]

[GROUT-305]: https://algolia.atlassian.net/browse/GROUT-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ