### PR TITLE
feat(dashboard): return API key UUID from CreateAPIKey

### DIFF
--- a/api/dashboard/client.go
+++ b/api/dashboard/client.go
@@ -544,34 +544,34 @@ func (c *Client) CreateAPIKey(
 	accessToken, appID string,
 	acl []string,
 	description string,
-) (string, error) {
+) (CreatedAPIKey, error) {
 	payload := CreateAPIKeyRequest{ACL: acl, Description: description}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return "", err
+		return CreatedAPIKey{}, err
 	}
 
 	endpoint := fmt.Sprintf("%s/1/applications/%s/api-keys", c.APIURL, url.PathEscape(appID))
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return "", err
+		return CreatedAPIKey{}, err
 	}
 	c.setAPIHeaders(req, accessToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("create API key request failed: %w", err)
+		return CreatedAPIKey{}, fmt.Errorf("create API key request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read API key response: %w", err)
+		return CreatedAPIKey{}, fmt.Errorf("failed to read API key response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf(
+		return CreatedAPIKey{}, fmt.Errorf(
 			"create API key failed with status %d: %s",
 			resp.StatusCode,
 			string(respBody),
@@ -580,7 +580,7 @@ func (c *Client) CreateAPIKey(
 
 	var keyResp CreateAPIKeyResponse
 	if err := json.Unmarshal(respBody, &keyResp); err != nil {
-		return "", fmt.Errorf(
+		return CreatedAPIKey{}, fmt.Errorf(
 			"failed to parse API key response: %w (body: %s)",
 			err,
 			string(respBody),
@@ -589,13 +589,13 @@ func (c *Client) CreateAPIKey(
 
 	key := keyResp.Data.Attributes.Value
 	if key == "" {
-		return "", fmt.Errorf(
+		return CreatedAPIKey{}, fmt.Errorf(
 			"API key creation succeeded but no key was returned in the response: %s",
 			string(respBody),
 		)
 	}
 
-	return key, nil
+	return CreatedAPIKey{Value: key, UUID: keyResp.Data.ID}, nil
 }
 
 // GetCrawlerUser gets the crawler API user data for the current authenticated user

--- a/api/dashboard/client_test.go
+++ b/api/dashboard/client_test.go
@@ -293,6 +293,31 @@ func TestCreateApplication_Success(t *testing.T) {
 	assert.Equal(t, "My App", app.Name)
 }
 
+func TestCreateAPIKey_ReturnsValueAndUUID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/applications/APP1/api-keys", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(CreateAPIKeyResponse{
+			Data: APIKeyResource{
+				ID:         "key-uuid-123",
+				Type:       "api_key",
+				Attributes: APIKeyAttributes{Value: "secret-key"},
+			},
+		}))
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	created, err := client.CreateAPIKey("test-token", "APP1", WriteACL, "Algolia CLI")
+	require.NoError(t, err)
+	assert.Equal(t, "secret-key", created.Value)
+	assert.Equal(t, "key-uuid-123", created.UUID)
+}
+
 func TestUpdateApplication_Success(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/1/applications/APP1", func(w http.ResponseWriter, r *http.Request) {

--- a/api/dashboard/client_test.go
+++ b/api/dashboard/client_test.go
@@ -318,6 +318,26 @@ func TestCreateAPIKey_ReturnsValueAndUUID(t *testing.T) {
 	assert.Equal(t, "key-uuid-123", created.UUID)
 }
 
+func TestCreateAPIKey_EmptyValueReturnsError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/applications/APP1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(CreateAPIKeyResponse{
+			Data: APIKeyResource{
+				ID:         "key-uuid-123",
+				Attributes: APIKeyAttributes{Value: ""},
+			},
+		}))
+	})
+
+	ts, client := newTestClient(mux)
+	defer ts.Close()
+
+	_, err := client.CreateAPIKey("test-token", "APP1", WriteACL, "Algolia CLI")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no key was returned")
+}
+
 func TestUpdateApplication_Success(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/1/applications/APP1", func(w http.ResponseWriter, r *http.Request) {

--- a/api/dashboard/types.go
+++ b/api/dashboard/types.go
@@ -47,10 +47,11 @@ type ApplicationPlan struct {
 
 // Application is a flattened view of an Algolia application for CLI consumption.
 type Application struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	APIKey    string `json:"api_key,omitempty"`
-	PlanLabel string `json:"plan_label,omitempty"` // current plan label, e.g. "Grow Plus"
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	APIKey     string `json:"api_key,omitempty"`
+	APIKeyUUID string `json:"api_key_uuid,omitempty"`
+	PlanLabel  string `json:"plan_label,omitempty"` // current plan label, e.g. "Grow Plus"
 }
 
 // PaginationMeta contains page-based pagination metadata.
@@ -143,6 +144,13 @@ type APIKeyAttributes struct {
 // CreateAPIKeyResponse is the JSON:API response from POST /1/applications/{application_id}/api-keys.
 type CreateAPIKeyResponse struct {
 	Data APIKeyResource `json:"data"`
+}
+
+// CreatedAPIKey is the result of creating an API key: its secret value and its
+// UUID, used to reference the key when persisting or managing it later.
+type CreatedAPIKey struct {
+	Value string
+	UUID  string
 }
 
 // DashboardCrawlerUserData contains the user information from the crawler API

--- a/pkg/cmd/shared/apputil/create.go
+++ b/pkg/cmd/shared/apputil/create.go
@@ -129,13 +129,14 @@ func EnsureAPIKey(
 ) error {
 	cs := io.ColorScheme()
 	io.StartProgressIndicatorWithLabel("Generating API key")
-	apiKey, err := client.CreateAPIKey(accessToken, app.ID, dashboard.WriteACL, "Algolia CLI")
+	created, err := client.CreateAPIKey(accessToken, app.ID, dashboard.WriteACL, "Algolia CLI")
 	io.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("failed to generate API key: %w", err)
 	}
 
-	app.APIKey = apiKey
+	app.APIKey = created.Value
+	app.APIKeyUUID = created.UUID
 	fmt.Fprintf(io.Out, "%s API key generated for application %s\n",
 		cs.SuccessIcon(), cs.Bold(app.ID))
 	return nil


### PR DESCRIPTION
## What

- `CreateAPIKey` now returns a `CreatedAPIKey{Value, UUID}` struct instead of just the secret value, exposing the key UUID (`data.id`) the dashboard API already returns.
- Adds an `APIKeyUUID` field to `dashboard.Application`; `EnsureAPIKey` populates it.
- `EnsureAPIKey`'s signature is unchanged, so its callers (`login`, `application create/select/list`) are untouched.
- The field is not consumed yet — a later step persists it to `state.toml`.

## Test

- Unit test asserts both value and UUID are returned: `go test ./api/dashboard -run TestCreateAPIKey -v`
- Full suite green: `go test ./...`
- Manually verified against the real dashboard API: creating a key returns a populated `data.id`.

[GROUT-305]

[GROUT-305]: https://algolia.atlassian.net/browse/GROUT-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ