### PR TITLE
feat(config): resolve credentials from state.toml + keychain

### DIFF
--- a/pkg/auth/auth_check.go
+++ b/pkg/auth/auth_check.go
@@ -49,7 +49,7 @@ func DisableAuthCheck(cmd *cobra.Command) {
 	cmd.Annotations["skipAuthCheck"] = "true"
 }
 
-func CheckAuth(cfg config.Config) error {
+func CheckAuth(cfg *config.Config) error {
 	if cfg.Profile().Name == "" {
 		cfg.Profile().LoadDefault()
 	}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -134,7 +134,7 @@ func Execute() exitCode {
 	// Set up the update notifier.
 	updateMessageChan := make(chan *update.ReleaseInfo)
 	go func() {
-		rel, err := checkForUpdate(cfg, version.Version)
+		rel, err := checkForUpdate(&cfg, version.Version)
 		if err != nil && hasDebug {
 			fmt.Fprintf(stderr, "Error checking for update: %s\n", err)
 		}
@@ -148,7 +148,7 @@ func Execute() exitCode {
 	authError := errors.New("authError")
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if auth.IsAuthCheckEnabled(cmd) {
-			if err := auth.CheckAuth(cfg); err != nil {
+			if err := auth.CheckAuth(&cfg); err != nil {
 				fmt.Fprintf(stderr, "Authentication error: %s\n", err)
 				fmt.Fprintln(
 					stderr,
@@ -305,7 +305,7 @@ func shouldCheckForUpdate() bool {
 	return !utils.IsCI() && utils.IsTerminal(os.Stdout) && utils.IsTerminal(os.Stderr)
 }
 
-func checkForUpdate(cfg config.Config, currentVersion string) (*update.ReleaseInfo, error) {
+func checkForUpdate(cfg *config.Config, currentVersion string) (*update.ReleaseInfo, error) {
 	if !shouldCheckForUpdate() {
 		return nil, nil
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,10 @@ type Config struct {
 	// state is the parsed state.toml, loaded once per command via loadState.
 	stateOnce sync.Once
 	state     *State
+
+	// activeApp is the resolved current application ID, computed once.
+	activeAppOnce sync.Once
+	activeApp     string
 }
 
 // InitConfig reads in profiles file and ENV variables if set.
@@ -102,6 +106,37 @@ func (c *Config) loadState() *State {
 		c.state = st
 	})
 	return c.state
+}
+
+// activeApplicationID resolves (once per command) which application the new
+// model should read against. Returns "" when no new-model app applies, so the
+// caller falls back to config.toml.
+func (c *Config) activeApplicationID() string {
+	c.activeAppOnce.Do(func() {
+		c.activeApp = c.resolveActiveApplicationID()
+	})
+	return c.activeApp
+}
+
+func (c *Config) resolveActiveApplicationID() string {
+	if v := os.Getenv("ALGOLIA_APPLICATION_ID"); v != "" {
+		return v
+	}
+
+	p := &c.CurrentProfile
+	if p.ApplicationID != "" { // --application-id flag
+		return p.ApplicationID
+	}
+
+	st := c.loadState()
+	if p.Name != "" { // --profile <name>: resolve against the stored alias
+		if appID, ok := st.ApplicationByAlias(p.Name); ok {
+			return appID
+		}
+		return "" // unknown alias → let the legacy config.toml profile-by-name handle it
+	}
+
+	return st.CurrentApplicationID
 }
 
 // ConfiguredProfiles return the profiles in the configuration file

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/BurntSushi/toml"
+	"github.com/algolia/cli/pkg/keychain"
 	"github.com/algolia/cli/pkg/utils"
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
@@ -49,6 +50,10 @@ type Config struct {
 	// activeApp is the resolved current application ID, computed once.
 	activeAppOnce sync.Once
 	activeApp     string
+
+	// secretsCache memoizes per-application keychain lookups (guarded by secretsMu).
+	secretsMu    sync.Mutex
+	secretsCache map[string]*keychain.AppSecrets
 }
 
 // InitConfig reads in profiles file and ENV variables if set.
@@ -137,6 +142,30 @@ func (c *Config) resolveActiveApplicationID() string {
 	}
 
 	return st.CurrentApplicationID
+}
+
+// appSecretsFor returns the cached keychain secrets for an application, loading
+// them once. A missing entry or a keychain failure yields nil, so resolution
+// falls back to config.toml. Guarded by a mutex since the getters may be
+// reached from more than one goroutine (e.g. the background update check).
+func (c *Config) appSecretsFor(appID string) *keychain.AppSecrets {
+	c.secretsMu.Lock()
+	defer c.secretsMu.Unlock()
+
+	if c.secretsCache == nil {
+		c.secretsCache = map[string]*keychain.AppSecrets{}
+	}
+	if cached, ok := c.secretsCache[appID]; ok {
+		return cached
+	}
+
+	secrets, err := keychain.LoadAppSecrets(appID)
+	if err != nil {
+		log.Warnf("ignoring keychain error for application %q: %s", appID, err)
+		secrets = nil
+	}
+	c.secretsCache[appID] = secrets
+	return secrets
 }
 
 // ConfiguredProfiles return the profiles in the configuration file

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -139,7 +139,9 @@ func (c *Config) resolveActiveApplicationID() string {
 	}
 
 	st := c.loadState()
-	if p.Name != "" { // --profile <name>: resolve against the stored alias
+	// Only a Name set explicitly (--profile flag) counts here: a name filled by
+	// LoadDefault must not shadow the state.toml current application.
+	if p.Name != "" && !p.nameFromDefault {
 		if appID, ok := st.ApplicationByAlias(p.Name); ok {
 			return appID
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/algolia/cli/pkg/utils"
@@ -38,7 +39,12 @@ type Config struct {
 
 	CurrentProfile Profile
 
-	File string
+	File      string
+	StateFile string
+
+	// state is the parsed state.toml, loaded once per command via loadState.
+	stateOnce sync.Once
+	state     *State
 }
 
 // InitConfig reads in profiles file and ENV variables if set.
@@ -49,6 +55,7 @@ func (c *Config) InitConfig() {
 		configFolder := c.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
 		configFile := filepath.Join(configFolder, "config.toml")
 		c.File = configFile
+		c.StateFile = filepath.Join(configFolder, "state.toml")
 		viper.SetConfigType("toml")
 		viper.SetConfigFile(configFile)
 		viper.SetConfigPermissions(os.FileMode(0o600))
@@ -80,6 +87,21 @@ func (c *Config) GetConfigFolder(xdgPath string) string {
 	}
 
 	return filepath.Join(configPath, "algolia")
+}
+
+// loadState reads state.toml once per command and caches it. A missing or
+// corrupt file degrades to an empty State so resolution can fall back to
+// config.toml rather than crash.
+func (c *Config) loadState() *State {
+	c.stateOnce.Do(func() {
+		st, err := LoadState(c.StateFile)
+		if err != nil {
+			log.Warnf("ignoring unreadable state file %q: %s", c.StateFile, err)
+			st = &State{Applications: map[string]ApplicationState{}}
+		}
+		c.state = st
+	})
+	return c.state
 }
 
 // ConfiguredProfiles return the profiles in the configuration file

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,6 +77,8 @@ func (c *Config) InitConfig() {
 		}
 	}
 
+	c.CurrentProfile.config = c
+
 	_ = viper.ReadInConfig()
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,10 @@ type IConfig interface {
 	Default() *Profile
 }
 
-// Config handles all overall configuration for the CLI
+// Config handles all overall configuration for the CLI.
+//
+// It must not be copied after InitConfig: it holds sync primitives (govet
+// copylocks) and CurrentProfile holds a back-pointer to it. Pass it by pointer.
 type Config struct {
 	ApplicationName string
 
@@ -147,9 +150,10 @@ func (c *Config) resolveActiveApplicationID() string {
 }
 
 // appSecretsFor returns the cached keychain secrets for an application, loading
-// them once. A missing entry or a keychain failure yields nil, so resolution
-// falls back to config.toml. Guarded by a mutex since the getters may be
-// reached from more than one goroutine (e.g. the background update check).
+// them once. A missing entry or a keychain failure yields nil (also cached, so
+// a single command never hits the keychain twice for the same app). The mutex
+// keeps the cache safe if a getter is ever called concurrently; resolution runs
+// on the main goroutine today.
 func (c *Config) appSecretsFor(appID string) *keychain.AppSecrets {
 	c.secretsMu.Lock()
 	defer c.secretsMu.Unlock()

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -81,6 +81,15 @@ func (p *Profile) GetAPIKey() (string, error) {
 		return p.APIKey, nil
 	}
 
+	// New model: active application's key from the OS keychain.
+	if p.config != nil {
+		if appID := p.config.activeApplicationID(); appID != "" {
+			if secrets := p.config.appSecretsFor(appID); secrets != nil && secrets.APIKey != "" {
+				return secrets.APIKey, nil
+			}
+		}
+	}
+
 	if p.Name == "" {
 		p.LoadDefault()
 	}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -22,6 +22,11 @@ type Profile struct {
 	SearchHosts   []string `mapstructure:"search_hosts"`
 
 	Default bool `mapstructure:"default"`
+
+	// config back-references the owning Config for new-model (state.toml +
+	// keychain) resolution. nil for standalone profiles (e.g. those returned by
+	// ConfiguredProfiles), which then resolve from config.toml only.
+	config *Config
 }
 
 func (p *Profile) GetFieldName(field string) string {
@@ -44,6 +49,13 @@ func (p *Profile) GetApplicationID() (string, error) {
 
 	if p.ApplicationID != "" {
 		return p.ApplicationID, nil
+	}
+
+	// New model: state.toml current/selected application.
+	if p.config != nil {
+		if appID := p.config.activeApplicationID(); appID != "" {
+			return appID, nil
+		}
 	}
 
 	if p.Name == "" {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -81,12 +81,14 @@ func (p *Profile) GetAPIKey() (string, error) {
 		return p.APIKey, nil
 	}
 
-	// New model: active application's key from the OS keychain.
+	// New model: once an application is resolved, its key comes only from that
+	// application's keychain entry — never a different profile's config.toml key.
 	if p.config != nil {
 		if appID := p.config.activeApplicationID(); appID != "" {
 			if secrets := p.config.appSecretsFor(appID); secrets != nil && secrets.APIKey != "" {
 				return secrets.APIKey, nil
 			}
+			return "", ErrAPIKeyNotConfigured
 		}
 	}
 
@@ -182,13 +184,15 @@ func (p *Profile) GetCrawlerAPIKey() (string, error) {
 		return os.Getenv("ALGOLIA_CRAWLER_API_KEY"), nil
 	}
 
-	// New model: active application's crawler key from the OS keychain.
+	// New model: once an application is resolved, its crawler key comes only from
+	// that application's keychain entry — never a different profile's.
 	if p.config != nil {
 		if appID := p.config.activeApplicationID(); appID != "" {
 			if secrets := p.config.appSecretsFor(appID); secrets != nil &&
 				secrets.CrawlerAPIKey != "" {
 				return secrets.CrawlerAPIKey, nil
 			}
+			return "", ErrCrawlerAPIKeyNotConfigured
 		}
 	}
 

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -182,6 +182,16 @@ func (p *Profile) GetCrawlerAPIKey() (string, error) {
 		return os.Getenv("ALGOLIA_CRAWLER_API_KEY"), nil
 	}
 
+	// New model: active application's crawler key from the OS keychain.
+	if p.config != nil {
+		if appID := p.config.activeApplicationID(); appID != "" {
+			if secrets := p.config.appSecretsFor(appID); secrets != nil &&
+				secrets.CrawlerAPIKey != "" {
+				return secrets.CrawlerAPIKey, nil
+			}
+		}
+	}
+
 	if p.Name == "" {
 		p.LoadDefault()
 	}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -27,6 +27,11 @@ type Profile struct {
 	// keychain) resolution. nil for standalone profiles (e.g. those returned by
 	// ConfiguredProfiles), which then resolve from config.toml only.
 	config *Config
+
+	// nameFromDefault records that Name was filled by LoadDefault rather than
+	// by an explicit --profile flag, so the new-model resolver doesn't let the
+	// legacy default profile shadow state.toml's current application.
+	nameFromDefault bool
 }
 
 func (p *Profile) GetFieldName(field string) string {
@@ -38,6 +43,7 @@ func (p *Profile) LoadDefault() {
 	for appName := range configs {
 		if viper.GetBool(appName + ".default") {
 			p.Name = appName
+			p.nameFromDefault = true
 		}
 	}
 }

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_LoadStateCachesAndToleratesMissing(t *testing.T) {
+	cfg := &Config{StateFile: filepath.Join(t.TempDir(), "state.toml")}
+
+	st := cfg.loadState()
+	require.NotNil(t, st)
+	assert.Empty(t, st.CurrentApplicationID)
+
+	// Second call returns the same cached pointer (loaded once).
+	assert.Same(t, st, cfg.loadState())
+}
+
+func TestConfig_LoadStateReadsFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte(
+			"current_application_id = \"APP1\"\n\n[applications.APP1]\nalias = \"prod\"\n",
+		),
+		0o600,
+	))
+
+	cfg := &Config{StateFile: path}
+	st := cfg.loadState()
+	assert.Equal(t, "APP1", st.CurrentApplicationID)
+	assert.Equal(t, "prod", st.Applications["APP1"].Alias)
+}

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -66,6 +66,12 @@ func TestConfig_ActiveApplicationID(t *testing.T) {
 		cfg := &Config{StateFile: path}
 		assert.Equal(t, "CURRENT", cfg.activeApplicationID())
 	})
+
+	t.Run("unknown profile alias defers to config.toml, not current", func(t *testing.T) {
+		cfg := &Config{StateFile: path}
+		cfg.CurrentProfile.Name = "nope"
+		assert.Empty(t, cfg.activeApplicationID()) // "" → legacy profile-by-name, not CURRENT
+	})
 }
 
 func TestConfig_AppSecretsForCaches(t *testing.T) {
@@ -78,6 +84,10 @@ func TestConfig_AppSecretsForCaches(t *testing.T) {
 	assert.Equal(t, "key-1", got.APIKey)
 
 	// Missing app → nil, and a keychain error must not panic.
+	assert.Nil(t, cfg.appSecretsFor("MISSING"))
+
+	// The nil result is cached: a later keychain write isn't picked up mid-command.
+	require.NoError(t, keychain.SaveAppSecrets("MISSING", keychain.AppSecrets{APIKey: "late"}))
 	assert.Nil(t, cfg.appSecretsFor("MISSING"))
 }
 
@@ -163,4 +173,33 @@ func TestProfile_FallsBackToConfigToml(t *testing.T) {
 	key, err := cfg.Profile().GetAPIKey()
 	require.NoError(t, err)
 	assert.Equal(t, "legacy-key", key)
+}
+
+func TestProfile_GetAPIKey_ActiveAppWithoutKeyErrors(t *testing.T) {
+	keyring.MockInit()
+	statePath := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(
+		t,
+		os.WriteFile(statePath, []byte("current_application_id = \"APP1\"\n"), 0o600),
+	)
+
+	// A legacy default profile whose key must NOT leak for the resolved APP1.
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(
+		configFile,
+		[]byte("[legacy]\napplication_id = \"LEGACY\"\napi_key = \"legacy-key\"\ndefault = true\n"),
+		0o600,
+	))
+	viper.Reset()
+	viper.SetConfigType("toml")
+	viper.SetConfigFile(configFile)
+	require.NoError(t, viper.ReadInConfig())
+	t.Cleanup(viper.Reset)
+
+	cfg := &Config{StateFile: statePath}
+	cfg.CurrentProfile.config = cfg
+
+	// APP1 resolved from state but no keychain key → error, never "legacy-key".
+	_, err := cfg.Profile().GetAPIKey()
+	require.Error(t, err)
 }

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/go-keyring"
@@ -119,4 +120,47 @@ func TestProfile_GetCrawlerAPIKey_FromKeychain(t *testing.T) {
 	key, err := cfg.Profile().GetCrawlerAPIKey()
 	require.NoError(t, err)
 	assert.Equal(t, "crawler-key", key)
+}
+
+func TestProfile_EnvWinsOverKeychain(t *testing.T) {
+	keyring.MockInit()
+	path := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(t, os.WriteFile(path, []byte("current_application_id = \"APP1\"\n"), 0o600))
+	require.NoError(t, keychain.SaveAppSecrets("APP1", keychain.AppSecrets{APIKey: "keychain-key"}))
+	t.Setenv("ALGOLIA_API_KEY", "env-key")
+
+	cfg := &Config{StateFile: path}
+	cfg.CurrentProfile.config = cfg
+
+	key, err := cfg.Profile().GetAPIKey()
+	require.NoError(t, err)
+	assert.Equal(t, "env-key", key) // env beats the keychain
+}
+
+func TestProfile_FallsBackToConfigToml(t *testing.T) {
+	// No state.toml entry and no keychain → resolve from the legacy config.toml.
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(
+		configFile,
+		[]byte(
+			"[legacy]\napplication_id = \"LEGACY_APP\"\napi_key = \"legacy-key\"\ndefault = true\n",
+		),
+		0o600,
+	))
+	viper.Reset()
+	viper.SetConfigType("toml")
+	viper.SetConfigFile(configFile)
+	require.NoError(t, viper.ReadInConfig())
+	t.Cleanup(viper.Reset)
+
+	cfg := &Config{StateFile: filepath.Join(t.TempDir(), "absent.toml")}
+	cfg.CurrentProfile.config = cfg
+
+	appID, err := cfg.Profile().GetApplicationID()
+	require.NoError(t, err)
+	assert.Equal(t, "LEGACY_APP", appID)
+
+	key, err := cfg.Profile().GetAPIKey()
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-key", key)
 }

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -35,3 +35,31 @@ func TestConfig_LoadStateReadsFile(t *testing.T) {
 	assert.Equal(t, "APP1", st.CurrentApplicationID)
 	assert.Equal(t, "prod", st.Applications["APP1"].Alias)
 }
+
+func TestConfig_ActiveApplicationID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte(
+			"current_application_id = \"CURRENT\"\n\n[applications.ALIASED]\nalias = \"prod\"\n",
+		),
+		0o600,
+	))
+
+	t.Run("env wins", func(t *testing.T) {
+		t.Setenv("ALGOLIA_APPLICATION_ID", "ENV_APP")
+		cfg := &Config{StateFile: path}
+		assert.Equal(t, "ENV_APP", cfg.activeApplicationID())
+	})
+
+	t.Run("profile alias resolves", func(t *testing.T) {
+		cfg := &Config{StateFile: path}
+		cfg.CurrentProfile.Name = "prod"
+		assert.Equal(t, "ALIASED", cfg.activeApplicationID())
+	})
+
+	t.Run("falls back to current_application_id", func(t *testing.T) {
+		cfg := &Config{StateFile: path}
+		assert.Equal(t, "CURRENT", cfg.activeApplicationID())
+	})
+}

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -175,6 +175,46 @@ func TestProfile_FallsBackToConfigToml(t *testing.T) {
 	assert.Equal(t, "legacy-key", key)
 }
 
+func TestProfile_DefaultedNameDoesNotMaskCurrentApplication(t *testing.T) {
+	// CheckAuth calls LoadDefault() before any getter runs. The defaulted
+	// legacy profile name must NOT be mistaken for an explicit --profile flag,
+	// otherwise the legacy default application silently wins over state.toml's
+	// current_application_id.
+	keyring.MockInit()
+	statePath := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(
+		t,
+		os.WriteFile(statePath, []byte("current_application_id = \"APP1\"\n"), 0o600),
+	)
+	require.NoError(t, keychain.SaveAppSecrets("APP1", keychain.AppSecrets{APIKey: "app1-key"}))
+
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(
+		configFile,
+		[]byte("[legacy]\napplication_id = \"LEGACY\"\napi_key = \"legacy-key\"\ndefault = true\n"),
+		0o600,
+	))
+	viper.Reset()
+	viper.SetConfigType("toml")
+	viper.SetConfigFile(configFile)
+	require.NoError(t, viper.ReadInConfig())
+	t.Cleanup(viper.Reset)
+
+	cfg := &Config{StateFile: statePath}
+	cfg.CurrentProfile.config = cfg
+
+	cfg.CurrentProfile.LoadDefault() // what CheckAuth does when no --profile is given
+	require.Equal(t, "legacy", cfg.CurrentProfile.Name)
+
+	appID, err := cfg.Profile().GetApplicationID()
+	require.NoError(t, err)
+	assert.Equal(t, "APP1", appID)
+
+	key, err := cfg.Profile().GetAPIKey()
+	require.NoError(t, err)
+	assert.Equal(t, "app1-key", key)
+}
+
 func TestProfile_GetAPIKey_ActiveAppWithoutKeyErrors(t *testing.T) {
 	keyring.MockInit()
 	statePath := filepath.Join(t.TempDir(), "state.toml")

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -79,3 +79,15 @@ func TestConfig_AppSecretsForCaches(t *testing.T) {
 	// Missing app → nil, and a keychain error must not panic.
 	assert.Nil(t, cfg.appSecretsFor("MISSING"))
 }
+
+func TestProfile_GetApplicationID_NewModel(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(t, os.WriteFile(path, []byte("current_application_id = \"APP1\"\n"), 0o600))
+
+	cfg := &Config{StateFile: path}
+	cfg.CurrentProfile.config = cfg
+
+	appID, err := cfg.Profile().GetApplicationID()
+	require.NoError(t, err)
+	assert.Equal(t, "APP1", appID)
+}

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -91,3 +91,32 @@ func TestProfile_GetApplicationID_NewModel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "APP1", appID)
 }
+
+func TestProfile_GetAPIKey_FromKeychain(t *testing.T) {
+	keyring.MockInit()
+	path := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(t, os.WriteFile(path, []byte("current_application_id = \"APP1\"\n"), 0o600))
+	require.NoError(t, keychain.SaveAppSecrets("APP1", keychain.AppSecrets{APIKey: "secret-key"}))
+
+	cfg := &Config{StateFile: path}
+	cfg.CurrentProfile.config = cfg
+
+	key, err := cfg.Profile().GetAPIKey()
+	require.NoError(t, err)
+	assert.Equal(t, "secret-key", key)
+}
+
+func TestProfile_GetCrawlerAPIKey_FromKeychain(t *testing.T) {
+	keyring.MockInit()
+	path := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(t, os.WriteFile(path, []byte("current_application_id = \"APP1\"\n"), 0o600))
+	require.NoError(t, keychain.SaveAppSecrets("APP1",
+		keychain.AppSecrets{APIKey: "k", CrawlerAPIKey: "crawler-key"}))
+
+	cfg := &Config{StateFile: path}
+	cfg.CurrentProfile.config = cfg
+
+	key, err := cfg.Profile().GetCrawlerAPIKey()
+	require.NoError(t, err)
+	assert.Equal(t, "crawler-key", key)
+}

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/pkg/keychain"
 )
 
 func TestConfig_LoadStateCachesAndToleratesMissing(t *testing.T) {
@@ -62,4 +65,17 @@ func TestConfig_ActiveApplicationID(t *testing.T) {
 		cfg := &Config{StateFile: path}
 		assert.Equal(t, "CURRENT", cfg.activeApplicationID())
 	})
+}
+
+func TestConfig_AppSecretsForCaches(t *testing.T) {
+	keyring.MockInit()
+	require.NoError(t, keychain.SaveAppSecrets("APP1", keychain.AppSecrets{APIKey: "key-1"}))
+
+	cfg := &Config{}
+	got := cfg.appSecretsFor("APP1")
+	require.NotNil(t, got)
+	assert.Equal(t, "key-1", got.APIKey)
+
+	// Missing app → nil, and a keychain error must not panic.
+	assert.Nil(t, cfg.appSecretsFor("MISSING"))
 }


### PR DESCRIPTION
## What

- Rewires the `Profile` getters so the CLI resolves credentials from the new model first, falling back to `config.toml` — no command or `IConfig`/`Profile` interface changes.
- `GetApplicationID` / `GetAPIKey` / `GetCrawlerAPIKey`: env → in-memory flag → active app's `state.toml` + OS keychain → `config.toml` → admin fallback.
- Active app resolved once per command by a shared `Config` resolver (env → `--application-id` → `--profile` alias → `state.toml` `current_application_id`); `state.toml` and per-app keychain secrets are loaded once and cached (avoids repeated keychain prompts).
- `Profile` gains an unexported `config` back-pointer (set in `InitConfig`, nil-guarded) so standalone profiles still resolve from `config.toml` only.
- First behaviour change of GROUT-305 (reads now prefer state.toml + keychain). Builds on #232 + #233.

## Test

- `go test ./pkg/config -run "TestConfig_|TestProfile_" -v`
- Full suite green; covers precedence (env > keychain) and the `config.toml` fallback for unmigrated/legacy profiles.

[GROUT-305]

[GROUT-305]: https://algolia.atlassian.net/browse/GROUT-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ