### PR TITLE
feat(config): write credentials to state.toml and the OS keychain

### DIFF
--- a/pkg/cmd/application/selectapp/select.go
+++ b/pkg/cmd/application/selectapp/select.go
@@ -122,44 +122,12 @@ func runSelectCmd(opts *SelectOptions) (*dashboard.Application, error) {
 		return nil, err
 	}
 
-	// If a profile already exists for this app, switch the default
-	// and ensure it has an API key.
-	if exists, profileName := opts.Config.ApplicationIDExists(chosen.ID); exists {
-		// Read the profile BEFORE SetDefaultProfile, because viper.Set() calls
-		// inside SetDefaultProfile pollute the override map and cause
-		// UnmarshalKey to return empty fields (known viper issue).
-		var existingProfile *config.Profile
-		for _, p := range opts.Config.ConfiguredProfiles() {
-			if p.Name == profileName {
-				existingProfile = p
-				break
-			}
+	// Reuse a key already stored for this application (keychain, then legacy
+	// config.toml) before creating a new one on the dashboard.
+	if !apputil.ReuseExistingAPIKey(opts.Config, chosen) {
+		if err := apputil.EnsureAPIKey(opts.IO, client, accessToken, chosen); err != nil {
+			return nil, err
 		}
-
-		if err := opts.Config.SetDefaultProfile(profileName); err != nil {
-			return nil, fmt.Errorf("failed to set default profile: %w", err)
-		}
-		fmt.Fprintf(opts.IO.Out, "%s Switched to profile %q (application %s).\n",
-			cs.SuccessIcon(), profileName, cs.Bold(chosen.ID))
-
-		if existingProfile != nil && existingProfile.APIKey == "" {
-			app := &dashboard.Application{ID: chosen.ID, Name: chosen.Name}
-			if err := apputil.EnsureAPIKey(opts.IO, client, accessToken, app); err != nil {
-				return nil, err
-			}
-			existingProfile.ApplicationID = chosen.ID
-			existingProfile.APIKey = app.APIKey
-			if err := existingProfile.Add(); err != nil {
-				return nil, err
-			}
-			fmt.Fprintf(opts.IO.Out, "%s Profile %q updated with API key.\n",
-				cs.SuccessIcon(), profileName)
-		}
-		return chosen, nil
-	}
-
-	if err := apputil.EnsureAPIKey(opts.IO, client, accessToken, chosen); err != nil {
-		return nil, err
 	}
 
 	if err := apputil.ConfigureProfile(opts.IO, opts.Config, chosen, "", true); err != nil {

--- a/pkg/cmd/auth/crawler/crawler.go
+++ b/pkg/cmd/auth/crawler/crawler.go
@@ -45,6 +45,14 @@ func NewCrawlerCmd(f *cmdutil.Factory) *cobra.Command {
 
 func runCrawlerCmd(opts *CrawlerOptions) error {
 	cs := opts.IO.ColorScheme()
+
+	appID := opts.config.ActiveApplicationID()
+	if appID == "" {
+		return fmt.Errorf(
+			"no application configured: run `algolia auth login` or `algolia application select` first",
+		)
+	}
+
 	dashboardClient := opts.NewDashboardClient(opts.OAuthClientID())
 
 	accessToken, err := opts.GetValidToken(dashboardClient)
@@ -59,24 +67,13 @@ func runCrawlerCmd(opts *CrawlerOptions) error {
 		return err
 	}
 
-	currentProfileName := opts.config.Profile().Name
-	if currentProfileName == "" {
-		defaultProfile := opts.config.Default()
-		if defaultProfile != nil {
-			currentProfileName = defaultProfile.Name
-			opts.config.Profile().Name = currentProfileName
-		}
-	}
-	if currentProfileName == "" {
-		return fmt.Errorf("no profile selected and no default profile configured")
-	}
-
-	if err = opts.config.SetCrawlerAuth(currentProfileName, crawlerUserData.ID, crawlerUserData.APIKey); err != nil {
+	if err := opts.config.SetCrawlerAPIKey(appID, crawlerUserData.APIKey); err != nil {
 		return err
 	}
 
 	if opts.IO.IsStdoutTTY() {
-		fmt.Fprintf(opts.IO.Out, "%s Crawler API auth credentials configured for profile: %s\n", cs.SuccessIcon(), currentProfileName)
+		fmt.Fprintf(opts.IO.Out, "%s Crawler API key configured for application: %s\n",
+			cs.SuccessIcon(), appID)
 	}
 
 	return nil

--- a/pkg/cmd/auth/crawler/crawler_test.go
+++ b/pkg/cmd/auth/crawler/crawler_test.go
@@ -15,15 +15,12 @@ import (
 	"github.com/algolia/cli/test"
 )
 
-func Test_runCrawlerCmd_UsesDefaultProfile(t *testing.T) {
+func Test_runCrawlerCmd_StoresCrawlerKeyForActiveApp(t *testing.T) {
 	io, _, stdout, _ := iostreams.Test()
 	io.SetStdoutTTY(true)
 
-	cfg := test.NewConfigStubWithProfiles([]*config.Profile{
-		{Name: "default", Default: true},
-		{Name: "other"},
-	})
-	cfg.CurrentProfile.Name = ""
+	cfg := test.NewDefaultConfigStub()
+	cfg.ActiveAppID = "APP1"
 
 	server := newCrawlerTestServer(t, "token-1", "crawler-user", "crawler-key")
 	t.Cleanup(server.Close)
@@ -39,39 +36,28 @@ func Test_runCrawlerCmd_UsesDefaultProfile(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, "default", cfg.CurrentProfile.Name)
-	assert.Equal(t, test.CrawlerAuth{UserID: "crawler-user", APIKey: "crawler-key"}, cfg.CrawlerAuth["default"])
-	assert.Contains(t, stdout.String(), "configured for profile: default")
+	assert.Equal(t, "crawler-key", cfg.CrawlerKeys["APP1"])
+	assert.Contains(t, stdout.String(), "configured for application: APP1")
 }
 
-func Test_runCrawlerCmd_UsesExplicitProfile(t *testing.T) {
+func Test_runCrawlerCmd_ErrorsWithoutActiveApplication(t *testing.T) {
 	io, _, stdout, _ := iostreams.Test()
-	io.SetStdoutTTY(true)
 
-	cfg := test.NewConfigStubWithProfiles([]*config.Profile{
-		{Name: "target"},
-		{Name: "default", Default: true},
-	})
-	cfg.CurrentProfile.Name = "target"
-
-	server := newCrawlerTestServer(t, "token-2", "crawler-user-2", "crawler-key-2")
-	t.Cleanup(server.Close)
+	cfg := test.NewDefaultConfigStub() // ActiveAppID left empty
 
 	err := runCrawlerCmd(&CrawlerOptions{
 		IO:                 io,
 		config:             cfg,
 		OAuthClientID:      func() string { return "test-client-id" },
-		NewDashboardClient: newDashboardTestClient(server),
+		NewDashboardClient: func(string) *dashboard.Client { return nil },
 		GetValidToken: func(client *dashboard.Client) (string, error) {
-			return "token-2", nil
+			return "", nil
 		},
 	})
-	require.NoError(t, err)
-
-	assert.Equal(t, test.CrawlerAuth{UserID: "crawler-user-2", APIKey: "crawler-key-2"}, cfg.CrawlerAuth["target"])
-	_, hasDefault := cfg.CrawlerAuth["default"]
-	assert.False(t, hasDefault)
-	assert.Contains(t, stdout.String(), "configured for profile: target")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no application configured")
+	assert.Empty(t, cfg.CrawlerKeys)
+	assert.Empty(t, stdout.String())
 }
 
 func Test_runCrawlerCmd_ReturnsCrawlerAPIError(t *testing.T) {
@@ -81,7 +67,7 @@ func Test_runCrawlerCmd_ReturnsCrawlerAPIError(t *testing.T) {
 	cfg := test.NewConfigStubWithProfiles([]*config.Profile{
 		{Name: "target"},
 	})
-	cfg.CurrentProfile.Name = "target"
+	cfg.ActiveAppID = "APP1"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer token-3", r.Header.Get("Authorization"))
@@ -104,7 +90,7 @@ func Test_runCrawlerCmd_ReturnsCrawlerAPIError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get crawler user data: crawler access denied")
-	assert.Empty(t, cfg.CrawlerAuth)
+	assert.Empty(t, cfg.CrawlerKeys)
 	assert.Empty(t, stdout.String())
 }
 

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -127,7 +127,7 @@ func RunOAuthFlow(ctx context.Context, opts *LoginOptions, signup bool) error {
 		}
 
 		appDetails = app
-		if !reuseExistingAPIKey(opts.Config, appDetails) {
+		if !apputil.ReuseExistingAPIKey(opts.Config, appDetails) {
 			if err := apputil.EnsureAPIKey(opts.IO, client, accessToken, appDetails); err != nil {
 				return err
 			}
@@ -166,18 +166,6 @@ func applyStoredIdentity(ctx context.Context) bool {
 
 	metadata.SetUser(token.UserID, token.Email, token.Name)
 	return true
-}
-
-// reuseExistingAPIKey checks if a local profile already has an API key for
-// the given application. If so, it sets app.APIKey and returns true.
-func reuseExistingAPIKey(cfg config.IConfig, app *dashboard.Application) bool {
-	for _, p := range cfg.ConfiguredProfiles() {
-		if p.ApplicationID == app.ID && p.APIKey != "" {
-			app.APIKey = p.APIKey
-			return true
-		}
-	}
-	return false
 }
 
 func selectApplication(opts *LoginOptions, apps []dashboard.Application, interactive bool) (*dashboard.Application, error) {

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -11,6 +11,8 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/transport"
 
 	"github.com/algolia/cli/api/crawler"
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
 	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/config"
 	"github.com/algolia/cli/pkg/iostreams"
@@ -72,15 +74,38 @@ func searchClient(f *cmdutil.Factory, appVersion string) func() (*search.APIClie
 	}
 }
 
+// fetchCrawlerUserID retrieves the crawler user ID from the dashboard API
+// using the stored OAuth token. The new model never stores it locally, so it
+// is fetched when needed. Overridable in tests.
+var fetchCrawlerUserID = func() (string, error) {
+	client := dashboard.NewClient(auth.OAuthClientID())
+	token, err := auth.GetValidToken(client)
+	if err != nil {
+		return "", err
+	}
+	user, err := client.GetCrawlerUser(token)
+	if err != nil {
+		return "", err
+	}
+	return user.ID, nil
+}
+
 func crawlerClient(f *cmdutil.Factory) func() (*crawler.Client, error) {
 	return func() (*crawler.Client, error) {
-		userID, err := f.Config.Profile().GetCrawlerUserID()
-		if err != nil {
-			return nil, err
-		}
 		APIKey, err := f.Config.Profile().GetCrawlerAPIKey()
 		if err != nil {
 			return nil, err
+		}
+
+		userID, err := f.Config.Profile().GetCrawlerUserID()
+		if err != nil {
+			userID, err = fetchCrawlerUserID()
+			if err != nil {
+				return nil, fmt.Errorf(
+					"the crawler user ID is not configured and could not be fetched (run `algolia auth login`): %w",
+					err,
+				)
+			}
 		}
 
 		return crawler.NewClient(userID, APIKey), nil

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -1,0 +1,70 @@
+package factory
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/config"
+)
+
+func Test_crawlerClient_UsesConfiguredUserID(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("ALGOLIA_CRAWLER_USER_ID", "configured-user")
+	t.Setenv("ALGOLIA_CRAWLER_API_KEY", "crawler-key")
+
+	called := false
+	old := fetchCrawlerUserID
+	fetchCrawlerUserID = func() (string, error) {
+		called = true
+		return "lazy-user", nil
+	}
+	t.Cleanup(func() { fetchCrawlerUserID = old })
+
+	f := New("1.0.0", &config.Config{})
+	_, err := f.CrawlerClient()
+	require.NoError(t, err)
+	assert.False(t, called)
+}
+
+func Test_crawlerClient_LazyFetchesUserID(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("ALGOLIA_CRAWLER_USER_ID", "")
+	t.Setenv("ALGOLIA_CRAWLER_API_KEY", "crawler-key")
+
+	called := false
+	old := fetchCrawlerUserID
+	fetchCrawlerUserID = func() (string, error) {
+		called = true
+		return "lazy-user", nil
+	}
+	t.Cleanup(func() { fetchCrawlerUserID = old })
+
+	f := New("1.0.0", &config.Config{})
+	_, err := f.CrawlerClient()
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func Test_crawlerClient_ErrorsWhenUserIDUnavailable(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("ALGOLIA_CRAWLER_USER_ID", "")
+	t.Setenv("ALGOLIA_CRAWLER_API_KEY", "crawler-key")
+
+	old := fetchCrawlerUserID
+	fetchCrawlerUserID = func() (string, error) {
+		return "", errors.New("no stored token")
+	}
+	t.Cleanup(func() { fetchCrawlerUserID = old })
+
+	f := New("1.0.0", &config.Config{})
+	_, err := f.CrawlerClient()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth login")
+}

--- a/pkg/cmd/shared/apputil/create.go
+++ b/pkg/cmd/shared/apputil/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/algolia/cli/api/dashboard"
 	"github.com/algolia/cli/pkg/config"
 	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/keychain"
 	"github.com/algolia/cli/pkg/prompt"
 )
 
@@ -142,8 +143,8 @@ func EnsureAPIKey(
 	return nil
 }
 
-// ConfigureProfile creates a CLI profile from application details and
-// optionally sets it as the default.
+// ConfigureProfile persists the application credentials in the new model
+// (state.toml + OS keychain) and optionally makes it the current application.
 func ConfigureProfile(
 	io *iostreams.IOStreams,
 	cfg config.IConfig,
@@ -161,31 +162,42 @@ func ConfigureProfile(
 	}
 	profileName = strings.ToLower(profileName)
 
-	if exists, existingAppID := cfg.ApplicationIDForProfile(profileName); exists && existingAppID != appDetails.ID {
+	// Another application already carries this alias: derive a unique one.
+	if otherID, ok := cfg.ApplicationIDByAlias(profileName); ok && otherID != appDetails.ID {
 		profileName = strings.ToLower(appDetails.Name + "-" + appDetails.ID)
 	}
 
-	profile := config.Profile{
-		Name:          profileName,
-		ApplicationID: appDetails.ID,
-		APIKey:        appDetails.APIKey,
-		Default:       setDefault,
-	}
-
-	if err := profile.Add(); err != nil {
+	if err := cfg.SaveApplication(
+		appDetails.ID, profileName, appDetails.APIKeyUUID, appDetails.APIKey, setDefault,
+	); err != nil {
 		return err
 	}
 
-	if setDefault {
-		if err := cfg.SetDefaultProfile(profileName); err != nil {
-			fmt.Fprintf(io.ErrOut, "%s Could not set default profile: %s\n", cs.WarningIcon(), err)
-		}
-	}
-
 	if io.IsStdoutTTY() {
-		fmt.Fprintf(io.Out, "%s Profile %q configured for application %s.\n",
-			cs.SuccessIcon(), profileName, cs.Bold(appDetails.ID))
+		fmt.Fprintf(io.Out, "%s Application %s configured (alias %q).\n",
+			cs.SuccessIcon(), cs.Bold(appDetails.ID), profileName)
 	}
 
 	return nil
+}
+
+// ReuseExistingAPIKey looks for an API key already stored for the application
+// (keychain first, then legacy config.toml profiles). If found, it sets
+// app.APIKey and returns true so callers skip creating a new key. A key reused
+// from a legacy profile has no known UUID, so api_key_uuid is left as-is.
+func ReuseExistingAPIKey(cfg config.IConfig, app *dashboard.Application) bool {
+	if secrets, err := keychain.LoadAppSecrets(app.ID); err == nil && secrets != nil &&
+		secrets.APIKey != "" {
+		app.APIKey = secrets.APIKey
+		return true
+	}
+
+	for _, p := range cfg.ConfiguredProfiles() {
+		if p.ApplicationID == app.ID && p.APIKey != "" {
+			app.APIKey = p.APIKey
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/cmd/shared/apputil/create_test.go
+++ b/pkg/cmd/shared/apputil/create_test.go
@@ -1,0 +1,83 @@
+package apputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/keychain"
+	"github.com/algolia/cli/test"
+)
+
+func TestConfigureProfile_SavesApplication(t *testing.T) {
+	io, _, _, _ := iostreams.Test()
+	cfg := test.NewDefaultConfigStub()
+	app := &dashboard.Application{
+		ID: "APP1", Name: "My App", APIKey: "key-1", APIKeyUUID: "uuid-1",
+	}
+
+	require.NoError(t, ConfigureProfile(io, cfg, app, "", true))
+
+	assert.Equal(t,
+		test.SavedApplication{Alias: "my app", APIKeyUUID: "uuid-1", APIKey: "key-1"},
+		cfg.SavedApps["APP1"])
+	assert.Equal(t, "APP1", cfg.CurrentAppID)
+}
+
+func TestConfigureProfile_ExplicitNameAndNoDefault(t *testing.T) {
+	io, _, _, _ := iostreams.Test()
+	cfg := test.NewDefaultConfigStub()
+	app := &dashboard.Application{ID: "APP1", Name: "My App", APIKey: "key-1"}
+
+	require.NoError(t, ConfigureProfile(io, cfg, app, "Prod", false))
+
+	assert.Equal(t, "prod", cfg.SavedApps["APP1"].Alias)
+	assert.Empty(t, cfg.CurrentAppID)
+}
+
+func TestConfigureProfile_AliasCollisionDerivesUniqueAlias(t *testing.T) {
+	io, _, _, _ := iostreams.Test()
+	cfg := test.NewDefaultConfigStub()
+	require.NoError(t, cfg.SaveApplication("OTHER", "my app", "", "other-key", false))
+
+	app := &dashboard.Application{ID: "APP1", Name: "My App", APIKey: "key-1"}
+	require.NoError(t, ConfigureProfile(io, cfg, app, "", true))
+
+	assert.Equal(t, "my app-app1", cfg.SavedApps["APP1"].Alias)
+}
+
+func TestReuseExistingAPIKey_FromKeychain(t *testing.T) {
+	keyring.MockInit()
+	require.NoError(t, keychain.SaveAppSecrets("APP1",
+		keychain.AppSecrets{APIKey: "stored-key"}))
+	cfg := test.NewDefaultConfigStub()
+	app := &dashboard.Application{ID: "APP1"}
+
+	assert.True(t, ReuseExistingAPIKey(cfg, app))
+	assert.Equal(t, "stored-key", app.APIKey)
+}
+
+func TestReuseExistingAPIKey_FromLegacyProfile(t *testing.T) {
+	keyring.MockInit() // empty keychain → falls through to config.toml profiles
+	cfg := test.NewConfigStubWithProfiles([]*config.Profile{
+		{Name: "legacy", ApplicationID: "APP1", APIKey: "legacy-key"},
+	})
+	app := &dashboard.Application{ID: "APP1"}
+
+	assert.True(t, ReuseExistingAPIKey(cfg, app))
+	assert.Equal(t, "legacy-key", app.APIKey)
+}
+
+func TestReuseExistingAPIKey_NotFound(t *testing.T) {
+	keyring.MockInit()
+	cfg := test.NewDefaultConfigStub()
+	app := &dashboard.Application{ID: "APP1"}
+
+	assert.False(t, ReuseExistingAPIKey(cfg, app))
+	assert.Empty(t, app.APIKey)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,12 @@ type IConfig interface {
 
 	SetCrawlerAuth(profileName, crawlerUserID, crawlerAPIKey string) error
 
+	// New model (state.toml + OS keychain).
+	ActiveApplicationID() string
+	ApplicationIDByAlias(alias string) (string, bool)
+	SaveApplication(appID, alias, apiKeyUUID, apiKey string, setCurrent bool) error
+	SetCrawlerAPIKey(appID, crawlerAPIKey string) error
+
 	Profile() *Profile
 	Default() *Profile
 }

--- a/pkg/config/write.go
+++ b/pkg/config/write.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"github.com/algolia/cli/pkg/keychain"
+)
+
+// ActiveApplicationID exposes the application resolved by the new model
+// (env → flag → state.toml alias → current application). Empty when only the
+// legacy config.toml could answer.
+func (c *Config) ActiveApplicationID() string {
+	return c.activeApplicationID()
+}
+
+// ApplicationIDByAlias returns the application ID carrying the given alias in
+// state.toml, and whether one was found.
+func (c *Config) ApplicationIDByAlias(alias string) (string, bool) {
+	return c.loadState().ApplicationByAlias(alias)
+}
+
+// SaveApplication persists an application's credentials in the new model.
+// The keychain is written first so a failure never leaves state.toml pointing
+// at a key that was not stored. Empty alias/apiKeyUUID preserve the values
+// already in state.toml, and an existing crawler key is preserved.
+//
+// Note: a command that already resolved its active application keeps that
+// resolution for the rest of the command (per-command cache).
+func (c *Config) SaveApplication(appID, alias, apiKeyUUID, apiKey string, setCurrent bool) error {
+	secrets, err := keychain.LoadAppSecrets(appID)
+	if err != nil {
+		return err
+	}
+	if secrets == nil {
+		secrets = &keychain.AppSecrets{}
+	}
+	secrets.APIKey = apiKey
+	if err := keychain.SaveAppSecrets(appID, *secrets); err != nil {
+		return err
+	}
+	c.cacheSecrets(appID, secrets)
+
+	st := c.loadState()
+	app := st.Applications[appID]
+	if alias != "" {
+		app.Alias = alias
+	}
+	if apiKeyUUID != "" {
+		app.APIKeyUUID = apiKeyUUID
+	}
+	st.UpsertApplication(appID, app)
+	if setCurrent {
+		st.SetCurrentApplication(appID)
+	}
+
+	return st.Save(c.StateFile)
+}
+
+// SetCrawlerAPIKey stores the crawler API key in the keychain entry of the
+// given application, preserving the search API key (load-modify-save).
+func (c *Config) SetCrawlerAPIKey(appID, crawlerAPIKey string) error {
+	secrets, err := keychain.LoadAppSecrets(appID)
+	if err != nil {
+		return err
+	}
+	if secrets == nil {
+		secrets = &keychain.AppSecrets{}
+	}
+	secrets.CrawlerAPIKey = crawlerAPIKey
+	if err := keychain.SaveAppSecrets(appID, *secrets); err != nil {
+		return err
+	}
+	c.cacheSecrets(appID, secrets)
+
+	return nil
+}
+
+// cacheSecrets refreshes the per-command secrets cache after a write so reads
+// in the same command observe the new values.
+func (c *Config) cacheSecrets(appID string, secrets *keychain.AppSecrets) {
+	c.secretsMu.Lock()
+	defer c.secretsMu.Unlock()
+	if c.secretsCache == nil {
+		c.secretsCache = map[string]*keychain.AppSecrets{}
+	}
+	c.secretsCache[appID] = secrets
+}

--- a/pkg/config/write_test.go
+++ b/pkg/config/write_test.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/pkg/keychain"
+)
+
+func TestConfig_SaveApplication_WritesKeychainThenState(t *testing.T) {
+	keyring.MockInit()
+	cfg := &Config{StateFile: filepath.Join(t.TempDir(), "state.toml")}
+
+	require.NoError(t, cfg.SaveApplication("APP1", "prod", "uuid-1", "key-1", true))
+
+	secrets, err := keychain.LoadAppSecrets("APP1")
+	require.NoError(t, err)
+	require.NotNil(t, secrets)
+	assert.Equal(t, "key-1", secrets.APIKey)
+
+	st, err := LoadState(cfg.StateFile)
+	require.NoError(t, err)
+	assert.Equal(t, "APP1", st.CurrentApplicationID)
+	assert.Equal(t,
+		ApplicationState{APIKeyUUID: "uuid-1", Alias: "prod"},
+		st.Applications["APP1"])
+}
+
+func TestConfig_SaveApplication_PreservesExistingValues(t *testing.T) {
+	keyring.MockInit()
+	cfg := &Config{StateFile: filepath.Join(t.TempDir(), "state.toml")}
+
+	require.NoError(t, keychain.SaveAppSecrets("APP1",
+		keychain.AppSecrets{APIKey: "old-key", CrawlerAPIKey: "crawler-key"}))
+	require.NoError(t, cfg.SaveApplication("APP1", "custom", "uuid-1", "old-key", false))
+
+	// Empty alias and UUID keep the stored values; the crawler key survives.
+	require.NoError(t, cfg.SaveApplication("APP1", "", "", "new-key", false))
+
+	secrets, err := keychain.LoadAppSecrets("APP1")
+	require.NoError(t, err)
+	assert.Equal(t, "new-key", secrets.APIKey)
+	assert.Equal(t, "crawler-key", secrets.CrawlerAPIKey)
+
+	st, err := LoadState(cfg.StateFile)
+	require.NoError(t, err)
+	assert.Equal(t,
+		ApplicationState{APIKeyUUID: "uuid-1", Alias: "custom"},
+		st.Applications["APP1"])
+	assert.Empty(t, st.CurrentApplicationID) // setCurrent was always false
+}
+
+func TestConfig_SaveApplication_KeychainErrorAborts(t *testing.T) {
+	keyring.MockInitWithError(errors.New("keychain locked"))
+	cfg := &Config{StateFile: filepath.Join(t.TempDir(), "state.toml")}
+
+	require.Error(t, cfg.SaveApplication("APP1", "prod", "uuid-1", "key-1", true))
+
+	// Keychain-first: state.toml must not exist after a keychain failure.
+	_, err := os.Stat(cfg.StateFile)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestConfig_SaveApplication_RefreshesSecretsCache(t *testing.T) {
+	keyring.MockInit()
+	cfg := &Config{StateFile: filepath.Join(t.TempDir(), "state.toml")}
+
+	// Prime the negative cache: nothing stored yet.
+	require.Nil(t, cfg.appSecretsFor("APP1"))
+
+	require.NoError(t, cfg.SaveApplication("APP1", "prod", "uuid-1", "key-1", true))
+
+	got := cfg.appSecretsFor("APP1")
+	require.NotNil(t, got)
+	assert.Equal(t, "key-1", got.APIKey)
+}
+
+func TestConfig_SetCrawlerAPIKey_PreservesSearchKey(t *testing.T) {
+	keyring.MockInit()
+	cfg := &Config{}
+
+	require.NoError(t, keychain.SaveAppSecrets("APP1",
+		keychain.AppSecrets{APIKey: "search-key"}))
+	require.NoError(t, cfg.SetCrawlerAPIKey("APP1", "crawler-key"))
+
+	secrets, err := keychain.LoadAppSecrets("APP1")
+	require.NoError(t, err)
+	assert.Equal(t, "search-key", secrets.APIKey)
+	assert.Equal(t, "crawler-key", secrets.CrawlerAPIKey)
+}
+
+func TestConfig_SetCrawlerAPIKey_CreatesEntryWhenMissing(t *testing.T) {
+	keyring.MockInit()
+	cfg := &Config{}
+
+	require.NoError(t, cfg.SetCrawlerAPIKey("APP1", "crawler-key"))
+
+	secrets, err := keychain.LoadAppSecrets("APP1")
+	require.NoError(t, err)
+	require.NotNil(t, secrets)
+	assert.Equal(t, "crawler-key", secrets.CrawlerAPIKey)
+	assert.Empty(t, secrets.APIKey)
+}
+
+func TestConfig_ActiveApplicationIDAndAliasAccessors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.toml")
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte("current_application_id = \"APP1\"\n\n[applications.APP1]\nalias = \"prod\"\n"),
+		0o600,
+	))
+	cfg := &Config{StateFile: path}
+
+	assert.Equal(t, "APP1", cfg.ActiveApplicationID())
+
+	appID, ok := cfg.ApplicationIDByAlias("prod")
+	assert.True(t, ok)
+	assert.Equal(t, "APP1", appID)
+}

--- a/test/config.go
+++ b/test/config.go
@@ -11,10 +11,22 @@ type CrawlerAuth struct {
 	APIKey string
 }
 
+// SavedApplication records what SaveApplication stored for an application.
+type SavedApplication struct {
+	Alias      string
+	APIKeyUUID string
+	APIKey     string
+}
+
 type ConfigStub struct {
 	CurrentProfile config.Profile
 	profiles       []*config.Profile
 	CrawlerAuth    map[string]CrawlerAuth
+
+	ActiveAppID  string
+	CurrentAppID string
+	SavedApps    map[string]SavedApplication
+	CrawlerKeys  map[string]string
 }
 
 func (c *ConfigStub) InitConfig() {}
@@ -128,4 +140,44 @@ func NewDefaultConfigStub() *ConfigStub {
 			Default:       true,
 		},
 	})
+}
+
+func (c *ConfigStub) ActiveApplicationID() string {
+	return c.ActiveAppID
+}
+
+func (c *ConfigStub) ApplicationIDByAlias(alias string) (string, bool) {
+	for appID, app := range c.SavedApps {
+		if app.Alias == alias {
+			return appID, true
+		}
+	}
+	return "", false
+}
+
+func (c *ConfigStub) SaveApplication(appID, alias, apiKeyUUID, apiKey string, setCurrent bool) error {
+	if c.SavedApps == nil {
+		c.SavedApps = map[string]SavedApplication{}
+	}
+	saved := c.SavedApps[appID]
+	if alias != "" {
+		saved.Alias = alias
+	}
+	if apiKeyUUID != "" {
+		saved.APIKeyUUID = apiKeyUUID
+	}
+	saved.APIKey = apiKey
+	c.SavedApps[appID] = saved
+	if setCurrent {
+		c.CurrentAppID = appID
+	}
+	return nil
+}
+
+func (c *ConfigStub) SetCrawlerAPIKey(appID, crawlerAPIKey string) error {
+	if c.CrawlerKeys == nil {
+		c.CrawlerKeys = map[string]string{}
+	}
+	c.CrawlerKeys[appID] = crawlerAPIKey
+	return nil
 }


### PR DESCRIPTION
## What

- `auth login`, `application create` and `application select` now persist credentials to the new model: API key in the OS keychain, `api_key_uuid` + alias + current application in `state.toml` (config.toml is no longer written by these flows)
- Keychain is written first, then `state.toml`, so a keychain failure never leaves state pointing at a missing key; empty alias/uuid preserve existing values, and the stored crawler key survives re-login
- `auth crawler` stores the crawler API key in the application's keychain entry; it now requires a new-model application (legacy-only users are told to run `algolia auth login`)
- The crawler user ID is no longer stored: the factory lazily fetches it from the dashboard API when env/config.toml can't provide it
- Existing keys are reused (keychain first, then legacy config.toml profiles) to avoid creating duplicate dashboard keys

## Test

1. `make build` — produces `./algolia` with the required ldflags (OAuth client ID, dashboard URL); a stable binary also avoids repeated macOS keychain prompts
2. `./algolia auth login` — then `cat ~/.config/algolia/state.toml`: expect `current_application_id`, plus `api_key_uuid` and `alias` under `[applications.<APP_ID>]`
   - note: `api_key_uuid` is only set when a fresh key was generated; if the key was reused (already in the keychain or in a legacy config.toml profile), it stays empty by design — same rule as the upcoming migration (GROUT-363)
3. `security find-generic-password -s algolia-cli -a "app:<APP_ID>" -w | sed 's/^go-keyring-base64://' | base64 -d` (macOS) — expect the `{"api_key": ...}` JSON entry; go-keyring's macOS backend stores values base64-encoded with a `go-keyring-base64:` prefix (decoded transparently on read)
4. `./algolia application select` — re-selecting the same application must NOT create a new dashboard key (key is reused); selecting another one updates `current_application_id`
5. `./algolia auth crawler` — adds `crawler_api_key` to the same keychain entry; then run any crawler command to exercise the lazy user-ID fetch
6. `./algolia indices list` — exercises the read path end to end; `config.toml`'s mtime must never change (these flows no longer write it)

> Stacked on #235 (`feat/read-resolution`); retarget to `feat/profile-depr` once #235 merges.

[GROUT-305]

[GROUT-305]: https://algolia.atlassian.net/browse/GROUT-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

