### PR TITLE
feat(profile): deprecate profile commands and --profile flag

### DIFF
--- a/pkg/cmd/application/create/create.go
+++ b/pkg/cmd/application/create/create.go
@@ -54,7 +54,7 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "create",
 		Short: "Create a new Algolia application",
 		Long: heredoc.Doc(`
-			Create a new Algolia application and optionally configure it as a CLI profile.
+			Create a new Algolia application and optionally set it as the current application.
 			Requires an active session (run "algolia auth login" first).`),
 		Example: heredoc.Doc(`
 			# Create an application interactively (prompts for name, plan, and terms)
@@ -66,7 +66,7 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 			# Create on a paid plan (requires a payment method on file)
 			$ algolia application create --name "My App" --region CA --plan grow --accept-terms
 
-			# Create and set the new profile as the default
+			# Create and set the new application as the current one
 			$ algolia application create --name "My App" --region CA --accept-terms --default
 
 			# Preview what would be created without actually creating it
@@ -85,10 +85,10 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.Name, "name", "My First Application", "Name for the application")
 	cmd.Flags().StringVar(&opts.Region, "region", "", "Region code (e.g. EU, UK, USC, USE, USW)")
 	cmd.Flags().
-		StringVar(&opts.ProfileName, "profile-name", "", "Name for the CLI profile (defaults to app name)")
+		StringVar(&opts.ProfileName, "profile-name", "", "Alias for the application (defaults to the app name)")
 	cmd.Flags().
 		StringVar(&opts.Plan, "plan", "", "Self-serve plan to create the application on (free, grow, grow-plus)")
-	cmd.Flags().BoolVar(&opts.Default, "default", false, "Set the new profile as the default")
+	cmd.Flags().BoolVar(&opts.Default, "default", false, "Set the new application as the current one")
 	cmd.Flags().
 		BoolVar(&opts.DryRun, "dry-run", false, "Preview the create request without sending it")
 	cmd.Flags().

--- a/pkg/cmd/application/downgrade/downgrade.go
+++ b/pkg/cmd/application/downgrade/downgrade.go
@@ -25,7 +25,7 @@ func NewDowngradeCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "downgrade",
 		Short: "Downgrade the current application to a lower-tier plan",
 		Long: heredoc.Doc(`
-			Change the application associated with the current CLI profile to a
+			Change the current application to a
 			lower-tier self-serve plan.
 
 			You must accept the target plan's terms of service before the change

--- a/pkg/cmd/application/list/list.go
+++ b/pkg/cmd/application/list/list.go
@@ -42,8 +42,8 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 		Long: heredoc.Doc(`
 			List all Algolia applications associated with your account.
 			Requires an active session (run "algolia auth login" first).
-			Applications that already have a local CLI profile are marked.
-			You can select an unconfigured application to add it as a CLI profile.
+			Applications already configured on this machine are marked.
+			You can select an unconfigured application to configure it.
 		`),
 		Example: heredoc.Doc(`
 			# List applications
@@ -117,7 +117,7 @@ func runListCmd(opts *ListOptions) error {
 		profileName, configured := configuredAppIDs[app.ID]
 		label := fmt.Sprintf("  %s  %s", app.ID, app.Name)
 		if configured {
-			fmt.Fprintf(opts.IO.Out, "%s  %s\n", label, cs.Greenf("(profile: %s)", profileName))
+			fmt.Fprintf(opts.IO.Out, "%s  %s\n", label, cs.Greenf("(configured: %s)", profileName))
 		} else {
 			fmt.Fprintf(opts.IO.Out, "%s  %s\n", label, cs.Gray("(not configured)"))
 			unconfigured = append(unconfigured, app)
@@ -127,7 +127,7 @@ func runListCmd(opts *ListOptions) error {
 	fmt.Fprintln(opts.IO.Out)
 
 	if len(unconfigured) == 0 {
-		fmt.Fprintf(opts.IO.Out, "%s All applications are already configured as CLI profiles.\n", cs.SuccessIcon())
+		fmt.Fprintf(opts.IO.Out, "%s All applications are already configured.\n", cs.SuccessIcon())
 		return nil
 	}
 
@@ -138,7 +138,7 @@ func runListCmd(opts *ListOptions) error {
 	var wantConfigure bool
 	err = prompt.SurveyAskOne(
 		&survey.Confirm{
-			Message: "Would you like to configure an unconfigured application as a CLI profile?",
+			Message: "Would you like to configure one of the unconfigured applications?",
 			Default: true,
 		},
 		&wantConfigure,
@@ -173,7 +173,7 @@ func runListCmd(opts *ListOptions) error {
 	var setDefault bool
 	err = prompt.SurveyAskOne(
 		&survey.Confirm{
-			Message: "Set as the default profile?",
+			Message: "Set as the current application?",
 			Default: false,
 		},
 		&setDefault,

--- a/pkg/cmd/application/planchange/planchange.go
+++ b/pkg/cmd/application/planchange/planchange.go
@@ -60,7 +60,7 @@ func Run(opts *Options) error {
 	appID, err := opts.Config.Profile().GetApplicationID()
 	if err != nil {
 		return fmt.Errorf(
-			"no current application configured; configure a profile with \"algolia profile add\" or \"algolia application select\" first: %w",
+			"no current application configured; run \"algolia auth login\" or \"algolia application select\" first: %w",
 			err,
 		)
 	}

--- a/pkg/cmd/application/selectapp/select.go
+++ b/pkg/cmd/application/selectapp/select.go
@@ -37,13 +37,14 @@ func NewSelectCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "select",
-		Short: "Select an application to use as the active profile",
+		Short: "Select the current application",
 		Long: heredoc.Doc(`
-			Select an Algolia application to use as the default CLI profile.
-			Fetches your applications from the API and lets you pick one.
+			Select an Algolia application to use as the current application for
+			all CLI commands. Fetches your applications from the API and lets
+			you pick one.
 
-			If the selected application already has a local profile, it is set
-			as the default. Otherwise, a new profile is created and set as default.
+			The application's API key is reused when one is already stored,
+			or generated otherwise, and saved securely in the OS keychain.
 		`),
 		Example: heredoc.Doc(`
 			# Select interactively

--- a/pkg/cmd/application/selectapp/select.go
+++ b/pkg/cmd/application/selectapp/select.go
@@ -42,9 +42,6 @@ func NewSelectCmd(f *cmdutil.Factory) *cobra.Command {
 			Select an Algolia application to use as the current application for
 			all CLI commands. Fetches your applications from the API and lets
 			you pick one.
-
-			The application's API key is reused when one is already stored,
-			or generated otherwise, and saved securely in the OS keychain.
 		`),
 		Example: heredoc.Doc(`
 			# Select interactively

--- a/pkg/cmd/application/update/update.go
+++ b/pkg/cmd/application/update/update.go
@@ -39,7 +39,7 @@ func NewUpdateCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "update",
 		Short: "Rename the current Algolia application",
 		Long: heredoc.Doc(`
-			Rename the application associated with the current CLI profile.
+			Rename the current application.
 			Requires an active application to be selected (run "algolia application select" first).
 		`),
 		Example: heredoc.Doc(`
@@ -69,7 +69,7 @@ func runUpdateCmd(opts *UpdateOptions) error {
 	appID, err := opts.Config.Profile().GetApplicationID()
 	if err != nil {
 		return fmt.Errorf(
-			"no current application configured; configure a profile with \"algolia profile add\" or \"algolia application select\" first: %w",
+			"no current application configured; run \"algolia auth login\" or \"algolia application select\" first: %w",
 			err,
 		)
 	}

--- a/pkg/cmd/application/upgrade/upgrade.go
+++ b/pkg/cmd/application/upgrade/upgrade.go
@@ -25,7 +25,7 @@ func NewUpgradeCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "upgrade",
 		Short: "Upgrade the current application to a higher-tier plan",
 		Long: heredoc.Doc(`
-			Change the application associated with the current CLI profile to a
+			Change the current application to a
 			higher-tier self-serve plan.
 
 			Paid plans require a payment method on your account; the CLI can't

--- a/pkg/cmd/auth/crawler/crawler.go
+++ b/pkg/cmd/auth/crawler/crawler.go
@@ -33,7 +33,7 @@ func NewCrawlerCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "crawler",
-		Short: "Load crawler auth details for the current profile",
+		Short: "Configure the crawler API key for the current application",
 		Args:  validators.NoArgs(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCrawlerCmd(opts)

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -78,8 +78,8 @@ func NewLoginCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.AppName, "app-name", "", "Auto-select application by name")
-	cmd.Flags().StringVar(&opts.ProfileName, "profile-name", "", "Name for the CLI profile (defaults to application name)")
-	cmd.Flags().BoolVar(&opts.Default, "default", true, "Set the profile as the default")
+	cmd.Flags().StringVar(&opts.ProfileName, "profile-name", "", "Alias for the application (defaults to the application name)")
+	cmd.Flags().BoolVar(&opts.Default, "default", true, "Set the application as the current one")
 	cmd.Flags().BoolVar(&opts.NoBrowser, "no-browser", false, "Print the authorize URL instead of opening the browser")
 
 	return cmd

--- a/pkg/cmd/auth/signup/signup.go
+++ b/pkg/cmd/auth/signup/signup.go
@@ -39,8 +39,8 @@ func NewSignupCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.AppName, "app-name", "", "Name for the first application")
-	cmd.Flags().StringVar(&opts.ProfileName, "profile-name", "", "Name for the CLI profile (defaults to application name)")
-	cmd.Flags().BoolVar(&opts.Default, "default", true, "Set the profile as the default")
+	cmd.Flags().StringVar(&opts.ProfileName, "profile-name", "", "Alias for the application (defaults to the application name)")
+	cmd.Flags().BoolVar(&opts.Default, "default", true, "Set the application as the current one")
 	cmd.Flags().BoolVar(&opts.NoBrowser, "no-browser", false, "Print the authorize URL instead of opening the browser")
 
 	return cmd

--- a/pkg/cmd/crawler/crawler.go
+++ b/pkg/cmd/crawler/crawler.go
@@ -23,7 +23,7 @@ import (
 const (
 	AuthMethodHelpMsg = `In order to use the 'crawler' commands, you will need to authenticate with the Algolia Crawler API. You can do so by either:
   - Export your Algolia Crawler username and API Key as ALGOLIA_CRAWLER_USER_ID and ALGOLIA_CRAWLER_API_KEY environment variables.
-  - Add your Algolia Crawler 'crawler_user_id' and 'crawler_api_key' credentials to your profile file (~/.config/algolia/config.tml).`
+  - Run 'algolia auth crawler' to store your crawler API key securely in the OS keychain.`
 )
 
 // NewCrawlersCmd returns a new command to manage your Algolia Crawlers.

--- a/pkg/cmd/profile/add/add.go
+++ b/pkg/cmd/profile/add/add.go
@@ -82,7 +82,7 @@ func NewAddCmd(f *cmdutil.Factory, runF func(*AddOptions) error) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:   "add",
 		Args:  validators.NoArgs(),
-		Short: "Add a new profile configuration to the CLI",
+		Short: "[Deprecated] Add a new profile configuration to the CLI",
 		Example: heredoc.Doc(`
 			# Add a new profile (interactive)
 			$ algolia profile add
@@ -139,6 +139,8 @@ func NewAddCmd(f *cmdutil.Factory, runF func(*AddOptions) error) *cobra.Command 
 
 // runAddCmd executes the add command
 func runAddCmd(opts *AddOptions) error {
+	fmt.Fprintf(opts.IO.ErrOut,
+		"warning: `algolia profile add` is deprecated, use `algolia auth login` or `algolia application select` instead\n")
 	var defaultProfile *config.Profile
 	for _, profile := range opts.config.ConfiguredProfiles() {
 		if profile.Default {

--- a/pkg/cmd/profile/application.go
+++ b/pkg/cmd/profile/application.go
@@ -16,7 +16,7 @@ func NewProfileCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "profile",
 		Aliases: []string{"profiles"},
-		Short:   "Manage your Algolia CLI profiles",
+		Short:   "[Deprecated] Manage your Algolia CLI profiles",
 	}
 
 	auth.DisableAuthCheck(cmd)

--- a/pkg/cmd/profile/list/list.go
+++ b/pkg/cmd/profile/list/list.go
@@ -32,7 +32,7 @@ func NewListCmd(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Use:     "list",
 		Aliases: []string{"l"},
 		Args:    validators.NoArgs(),
-		Short:   "List the configured profile(s)",
+		Short:   "[Deprecated] List the configured profile(s)",
 		Example: heredoc.Doc(`
 			# List the configured profiles
 			$ algolia profile list
@@ -51,6 +51,8 @@ func NewListCmd(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 // runListCmd executes the list command
 func runListCmd(opts *ListOptions) error {
+	fmt.Fprintf(opts.IO.ErrOut,
+		"warning: `algolia profile list` is deprecated, use `algolia application list` instead\n")
 	profiles := opts.config.ConfiguredProfiles()
 	if len(profiles) == 0 {
 		fmt.Fprintln(opts.IO.ErrOut, "No configured profiles")

--- a/pkg/cmd/profile/remove/remove.go
+++ b/pkg/cmd/profile/remove/remove.go
@@ -37,7 +37,7 @@ func NewRemoveCmd(f *cmdutil.Factory, runF func(*RemoveOptions) error) *cobra.Co
 		Use:               "remove <profile>",
 		Args:              validators.ExactArgs(1),
 		ValidArgsFunction: cmdutil.ConfiguredProfilesCompletionFunc(f),
-		Short:             "Remove the specified profile",
+		Short:             "[Deprecated] Remove the specified profile",
 		Long:              `Remove the specified profile from the configuration.`,
 		Example: heredoc.Doc(`
 			# Remove the profile named "my-app" from the configuration
@@ -81,6 +81,8 @@ func NewRemoveCmd(f *cmdutil.Factory, runF func(*RemoveOptions) error) *cobra.Co
 
 // runRemoveCmd executes the remove command
 func runRemoveCmd(opts *RemoveOptions) error {
+	fmt.Fprintf(opts.IO.ErrOut,
+		"warning: `algolia profile remove` is deprecated, profiles are replaced by `algolia application select` and the OS keychain\n")
 	if opts.DoConfirm {
 		var confirmed bool
 		err := prompt.Confirm(

--- a/pkg/cmd/profile/setdefault/setdefault.go
+++ b/pkg/cmd/profile/setdefault/setdefault.go
@@ -30,7 +30,7 @@ func NewSetDefaultCmd(f *cmdutil.Factory, runF func(*SetDefaultOptions) error) *
 		Use:               "setdefault <profile>",
 		Args:              validators.ExactArgs(1),
 		ValidArgsFunction: cmdutil.ConfiguredProfilesCompletionFunc(f),
-		Short:             "Set the default profile",
+		Short:             "[Deprecated] Set the default profile",
 		Example: heredoc.Doc(`
 			# Set the default profile to "my-app"
 			$ algolia profile setdefault my-app
@@ -55,6 +55,8 @@ func NewSetDefaultCmd(f *cmdutil.Factory, runF func(*SetDefaultOptions) error) *
 
 // runSetDefaultCmd executes the setdefault command
 func runSetDefaultCmd(opts *SetDefaultOptions) error {
+	fmt.Fprintf(opts.IO.ErrOut,
+		"warning: `algolia profile setdefault` is deprecated, use `algolia application select` instead\n")
 	var defaultName string
 	for _, profile := range opts.config.ConfiguredProfiles() {
 		if profile.Default {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -83,11 +83,14 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.PersistentFlags().
 		StringVarP(&f.Config.Profile().Name, "profile", "p", "", "The profile to use")
+	_ = cmd.PersistentFlags().
+		MarkDeprecated("profile", "use --application-id or 'algolia application select' instead")
 	_ = cmd.RegisterFlagCompletionFunc("profile", cmdutil.ConfiguredProfilesCompletionFunc(f))
 
 	cmd.PersistentFlags().
-		StringVarP(&f.Config.Profile().ApplicationID, "application-id", "", "", "The application ID")
-	cmd.PersistentFlags().StringVarP(&f.Config.Profile().APIKey, "api-key", "", "", "The API key")
+		StringVarP(&f.Config.Profile().ApplicationID, "application-id", "", "", "The application ID (defaults to the current application, set with 'algolia application select')")
+	cmd.PersistentFlags().
+		StringVarP(&f.Config.Profile().APIKey, "api-key", "", "", "The API key (defaults to the key stored for the current application)")
 	cmd.PersistentFlags().
 		StringVarP(&f.Config.Profile().AdminAPIKey, "admin-api-key", "", "", "The admin API key")
 	_ = cmd.PersistentFlags().MarkDeprecated("admin-api-key", "use --api-key instead")
@@ -152,7 +155,7 @@ func Execute() exitCode {
 				fmt.Fprintf(stderr, "Authentication error: %s\n", err)
 				fmt.Fprintln(
 					stderr,
-					"Please run `algolia profile add` to configure your first profile.",
+					"Please run `algolia auth login` to get started.",
 				)
 				return authError
 			}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -83,8 +83,10 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.PersistentFlags().
 		StringVarP(&f.Config.Profile().Name, "profile", "p", "", "The profile to use")
-	_ = cmd.PersistentFlags().
-		MarkDeprecated("profile", "use --application-id or 'algolia application select' instead")
+	// Deprecated but kept visible in help (MarkDeprecated would also hide it).
+	cmd.PersistentFlags().
+		Lookup("profile").
+		Deprecated = "use --application-id or 'algolia application select' instead"
 	_ = cmd.RegisterFlagCompletionFunc("profile", cmdutil.ConfiguredProfilesCompletionFunc(f))
 
 	cmd.PersistentFlags().


### PR DESCRIPTION
## What

- The `--profile` flag is deprecated: still visible in help with a `(DEPRECATED: ...)` note, and prints a warning when used (pointing to `--application-id` or `algolia application select`)
- The `--application-id` and `--api-key` global flag descriptions now document their defaults (current application / its stored key)
- The `profile` commands (`add`, `list`, `remove`, `setdefault`) are marked `[Deprecated]` in help (kept visible) and print a stderr warning pointing to their replacement (`auth login`, `application list`, `application select`); `profile remove` has no new-model equivalent yet
- The auth failure hint now says `Please run 'algolia auth login' to get started.` instead of pointing to `profile add`
- All remaining user-facing help texts, prompts, and error messages were reworded from "CLI profile" to the current-application model (`auth login`/`signup`, `application select`/`create`/`list`/`update`/`upgrade`/`downgrade`, crawler auth help)

## Test

`make build`, then:

  1. `./algolia --help` — `--profile` listed with `(DEPRECATED: ...)`; new `--application-id`/`--api-key` descriptions; `profile` group listed with `[Deprecated]`
  2. `./algolia indices list -p <alias>` — deprecation warning on stderr, command still works
  3. `./algolia profile --help` — all 4 subcommands visible with `[Deprecated]`; running any of them prints the replacement hint on stderr
  4. `./algolia application select|create|list|update|upgrade|downgrade --help` and `./algolia auth login|signup|crawler --help` — no more "CLI profile" wording

[GROUT-305](https://algolia.atlassian.net/browse/GROUT-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[GROUT-305]: https://algolia.atlassian.net/browse/GROUT-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ