### PR TITLE
feat(telemetry): send the build environment to the telemetry proxy

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/http"
 	"runtime"
 	"sync/atomic"
 
@@ -19,8 +20,10 @@ import (
 )
 
 const (
-	AppName               = "cli"
-	telemetryAnalyticsURL = "https://telemetry-proxy.algolia.com/"
+	AppName = "cli"
+	// No trailing slash: analytics-go appends "/v1/batch" to the endpoint.
+	telemetryAnalyticsURL = "https://telemetry-proxy.algolia.com"
+	envHeader             = "X-Algolia-CLI-Env"
 )
 
 type telemetryMetadataKey struct{}
@@ -68,11 +71,41 @@ func NewAnalyticsTelemetryClient(debug bool) (TelemetryClient, error) {
 		Endpoint: telemetryAnalyticsURL,
 		Logger:   newTelemetryLogger(debug),
 		Verbose:  debug,
+		Transport: &envHeaderTransport{
+			base: http.DefaultTransport,
+			env:  telemetryEnv(),
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
 	return &AnalyticsTelemetryClient{client: client}, nil
+}
+
+// envHeaderTransport adds the X-Algolia-CLI-Env header to every telemetry
+// request, so the proxy can route release builds to the production Segment
+// source and everything else to the development one. Until the proxy routes
+// on the header, all events keep going to the development source.
+type envHeaderTransport struct {
+	base http.RoundTripper
+	env  string
+}
+
+func (t *envHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// RoundTrippers must not mutate the caller's request.
+	req = req.Clone(req.Context())
+	req.Header.Set(envHeader, t.env)
+	return t.base.RoundTrip(req)
+}
+
+// telemetryEnv reports which environment the events belong to: "prod" for
+// release builds (goreleaser injects a semver version), "dev" for source
+// builds (the version stays "main").
+func telemetryEnv() string {
+	if version.Version == "main" {
+		return "dev"
+	}
+	return "prod"
 }
 
 // anonymousID is a unique identifier for an anonymous user of the CLI (basically the hash of the mac address)

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -9,7 +10,45 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/cli/pkg/version"
 )
+
+// captureTransport records the request it receives without hitting the network.
+type captureTransport struct {
+	req *http.Request
+}
+
+func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.req = req
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+}
+
+func TestEnvHeaderTransport_SetsHeaderWithoutMutatingRequest(t *testing.T) {
+	capture := &captureTransport{}
+	transport := &envHeaderTransport{base: capture, env: "prod"}
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/batch", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod", capture.req.Header.Get(envHeader))
+	// RoundTrippers must not mutate the caller's request.
+	assert.Empty(t, req.Header.Get(envHeader))
+}
+
+func TestTelemetryEnv(t *testing.T) {
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+
+	version.Version = "main"
+	assert.Equal(t, "dev", telemetryEnv())
+
+	version.Version = "1.20.0"
+	assert.Equal(t, "prod", telemetryEnv())
+}
 
 // Context-related tests.
 func TestEventMetadataWithGet(t *testing.T) {


### PR DESCRIPTION
## What

- Every telemetry request now carries an `X-Algolia-CLI-Env` header: `prod` for release builds (goreleaser injects a semver `version.Version`), `dev` for source builds (`version.Version` stays `"main"`). Deriving the environment from the build-time version (instead of an env var) makes it impossible to spoof or misconfigure at runtime: the split exactly mirrors "official release binary vs source build".
- **No behavior change today**: the proxy ignores the header until it routes on it, so everything keeps going to the "CLI (DEV)" source. Shipping the header now means already-released CLIs will switch over instantly the day the proxy routes.
- The transport clones the request before adding the header (RoundTrippers must not mutate the caller's request — unit-tested).
- Fixes the doubled slash in the telemetry URL (`telemetry-proxy.algolia.com//v1/batch`): the endpoint had a trailing slash and analytics-go appends `/v1/batch`.

**Remaining, outside this repo**: create the "CLI (PROD)" source in Segment, and have the telemetry-proxy team route on the header (absent header → DEV, as today).

## Test

The header isn't visible in DEBUG logs (the library doesn't log request headers); it is covered by unit tests. Manual check = no regression:

```sh
# events still flow, and the batch URL no longer has a double slash
DEBUG=1 go run ./cmd/algolia application plans
```

[GROUT-349]

[GROUT-349]: https://algolia.atlassian.net/browse/GROUT-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ