### PR TITLE
feat(telemetry): logout flow event

### DIFF
--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -1,6 +1,7 @@
 package logout
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -10,6 +11,7 @@ import (
 	"github.com/algolia/cli/pkg/auth"
 	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/telemetry"
 	"github.com/algolia/cli/pkg/validators"
 )
 
@@ -38,14 +40,14 @@ func NewLogoutCmd(f *cmdutil.Factory) *cobra.Command {
 		`),
 		Args: validators.NoArgs(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogoutCmd(opts)
+			return runLogoutCmd(cmd.Context(), opts)
 		},
 	}
 
 	return cmd
 }
 
-func runLogoutCmd(opts *LogoutOptions) error {
+func runLogoutCmd(ctx context.Context, opts *LogoutOptions) error {
 	cs := opts.IO.ColorScheme()
 	stored := auth.LoadToken()
 
@@ -67,6 +69,10 @@ func runLogoutCmd(opts *LogoutOptions) error {
 			fmt.Fprintf(opts.IO.ErrOut, "%s Failed to revoke refresh token: %s\n", cs.WarningIcon(), err)
 		}
 	}
+
+	// Tracked before clearing the local state, while the user identifier is
+	// still attached to the telemetry metadata.
+	telemetry.TrackEvent(ctx, telemetry.AuthLogout())
 
 	auth.ClearToken()
 

--- a/pkg/cmd/auth/logout/logout_test.go
+++ b/pkg/cmd/auth/logout/logout_test.go
@@ -1,0 +1,73 @@
+package logout
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/telemetry"
+	"github.com/algolia/cli/pkg/telemetry/telemetrytest"
+)
+
+func newLogoutOpts(srv *httptest.Server) *LogoutOptions {
+	io, _, _, _ := iostreams.Test()
+	return &LogoutOptions{
+		IO: io,
+		NewDashboardClient: func(string) *dashboard.Client {
+			c := dashboard.NewClientWithHTTPClient("test", srv.Client())
+			c.DashboardURL = srv.URL
+			return c
+		},
+	}
+}
+
+func TestLogout_EmitsAuthLogoutBeforeClearingToken(t *testing.T) {
+	keyring.MockInit()
+	t.Cleanup(auth.ClearToken)
+	require.NoError(t, auth.SaveToken(&dashboard.OAuthTokenResponse{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		ExpiresIn:    3600,
+	}))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/oauth/revoke", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := &telemetrytest.RecordingClient{}
+	ctx := telemetry.WithTelemetryClient(context.Background(), client)
+
+	require.NoError(t, runLogoutCmd(ctx, newLogoutOpts(srv)))
+
+	require.Len(t, client.Events, 1)
+	event := client.Events[0]
+	assert.Equal(t, telemetry.EventAuthLogout, event.Name)
+	assert.Equal(t, telemetry.FlowLogout, event.Properties["flow"])
+	// The token is cleared after the event was tracked.
+	assert.Nil(t, auth.LoadToken())
+	// No Identify at logout time: Segment cannot un-identify.
+	assert.Zero(t, client.Identifies)
+}
+
+func TestLogout_AlreadySignedOutEmitsNothing(t *testing.T) {
+	keyring.MockInit()
+	auth.ClearToken()
+
+	client := &telemetrytest.RecordingClient{}
+	ctx := telemetry.WithTelemetryClient(context.Background(), client)
+
+	require.NoError(t, runLogoutCmd(ctx, newLogoutOpts(nil)))
+
+	assert.Empty(t, client.Events)
+}

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -18,6 +18,7 @@ const (
 	EventAuthCompleted = "CLI Auth Completed"
 	EventAuthFailed    = "CLI Auth Failed"
 	EventAuthAborted   = "CLI Auth Aborted"
+	EventAuthLogout    = "CLI Auth Logout"
 
 	EventApplicationCreateStarted       = "CLI Application Create Started"
 	EventApplicationCreateAcceptedTerms = "CLI Application Create Accepted Terms"
@@ -40,6 +41,7 @@ type Flow string
 const (
 	FlowLogin  Flow = "login"
 	FlowSignup Flow = "signup"
+	FlowLogout Flow = "logout"
 )
 
 // Step locates where the user is inside an interactive flow, so aborts and
@@ -148,6 +150,16 @@ func AuthAborted(flow Flow, tracker *FlowTracker) Event {
 	return Event{EventAuthAborted, map[string]any{
 		"flow": flow,
 		"step": tracker.Step(),
+	}}
+}
+
+// AuthLogout is emitted when the user signs out. It must be tracked before
+// the local state is cleared, while the user identifier is still attached to
+// the telemetry metadata; no Identify follows, since Segment's identity graph
+// has no concept of un-identifying.
+func AuthLogout() Event {
+	return Event{EventAuthLogout, map[string]any{
+		"flow": FlowLogout,
 	}}
 }
 


### PR DESCRIPTION
## What

GROUT-351 — logout telemetry flow. **Stacked on #239** (`feat/auth-flow-events`): it only needs the event catalog and `TrackEvent` helper from the auth step, nothing from the create/plan-change work.

- `auth logout` emits `CLI Auth Logout` (`flow: logout`) **before** `auth.ClearToken()`, while the user identifier is still attached to the telemetry metadata — the event is attributed to the user signing out.
- No event when already signed out (no logout actually happened).
- **No `Identify` at logout time**: Segment's identity graph has no concept of un-identifying — once an `anonymousId` is aliased to a `userId`, the mapping persists by design.
- Subsequent events automatically stop carrying `userId`: `Track`/`Identify` only set the field when the metadata has one, and after `ClearToken()` the next invocations load no token. Events fall back to `anonymousId` attribution, like a fresh install.

## Test

```sh
# signed in: the final batch contains CLI Auth Logout {flow: logout}
DEBUG=1 go run ./cmd/algolia auth logout

# already signed out: no flow event
DEBUG=1 go run ./cmd/algolia auth logout
```

[GROUT-351]

[GROUT-351]: https://algolia.atlassian.net/browse/GROUT-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ