### PR TITLE
feat: add output formatting flags to more commands

### DIFF
--- a/pkg/cmd/apikeys/create/create.go
+++ b/pkg/cmd/apikeys/create/create.go
@@ -27,6 +27,8 @@ type CreateOptions struct {
 	Indices     []string
 	Referers    []string
 	Validity    time.Duration
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewCreateCmd returns a new instance of CreateCmd
@@ -35,6 +37,7 @@ func NewCreateCmd(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		IO:           f.IOStreams,
 		config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 	cmd := &cobra.Command{
 		Use:     "create",
@@ -138,6 +141,8 @@ func NewCreateCmd(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			"seeUnretrievableAttributes": "retrieve unretrievableAttributes for all operations that return records",
 		}, "can"))
 
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -163,6 +168,14 @@ func runCreateCmd(opts *CreateOptions) error {
 	res, err := client.AddApiKey(client.NewApiAddApiKeyRequest(&key))
 	if err != nil {
 		return err
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, res)
 	}
 
 	cs := opts.IO.ColorScheme()

--- a/pkg/cmd/dictionary/entries/clear/clear.go
+++ b/pkg/cmd/dictionary/entries/clear/clear.go
@@ -27,6 +27,8 @@ type ClearOptions struct {
 	All          bool
 
 	DoConfirm bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewClearCmd creates and returns a clear command for dictionaries' entries.
@@ -38,6 +40,7 @@ func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Comm
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 	cmd := &cobra.Command{
 		Use:       "clear {<dictionary>... | --all} [--confirm]",
@@ -100,6 +103,8 @@ func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Comm
 		BoolVarP(&confirm, "confirm", "y", false, "Skip the clear dictionary entry confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Clear all dictionaries")
 
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -153,17 +158,27 @@ func runClearCmd(opts *ClearOptions) error {
 		}
 	}
 
+	responses := make([]search.UpdatedAtResponse, 0, len(dictionaries))
 	for _, dict := range dictionaries {
 		batchParams := search.NewBatchDictionaryEntriesParams(
 			[]search.BatchDictionaryEntriesRequest{},
 			search.WithBatchDictionaryEntriesParamsClearExistingDictionaryEntries(true),
 		)
-		_, err := client.BatchDictionaryEntries(
+		res, err := client.BatchDictionaryEntries(
 			client.NewApiBatchDictionaryEntriesRequest(dict, batchParams),
 		)
 		if err != nil {
 			return err
 		}
+		responses = append(responses, *res)
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, responses)
 	}
 
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/dictionary/entries/clear/clear_test.go
+++ b/pkg/cmd/dictionary/entries/clear/clear_test.go
@@ -1,6 +1,7 @@
 package clear
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -206,4 +207,44 @@ func Test_runDeleteCmd(t *testing.T) {
 			assert.Equal(t, tt.wantOut, out.String())
 		})
 	}
+}
+
+// Test_runClearCmd_outputJSON checks that the --output json path emits one
+// response per cleared dictionary, in order — i.e. the collection loop.
+func Test_runClearCmd_outputJSON(t *testing.T) {
+	r := httpmock.Registry{}
+	dicts := []search.DictionaryType{
+		search.DICTIONARY_TYPE_PLURALS,
+		search.DICTIONARY_TYPE_COMPOUNDS,
+	}
+	for i, d := range dicts {
+		r.Register(
+			httpmock.REST("POST", fmt.Sprintf("1/dictionaries/%s/search", d)),
+			httpmock.JSONResponse(search.SearchDictionaryEntriesResponse{
+				Hits: []search.DictionaryEntry{
+					{
+						ObjectID: "1",
+						Language: search.SUPPORTED_LANGUAGE_EN.Ptr(),
+						Words:    []string{"foo"},
+						Type:     search.DICTIONARY_ENTRY_TYPE_CUSTOM.Ptr(),
+					},
+				},
+			}),
+		)
+		r.Register(
+			httpmock.REST("POST", fmt.Sprintf("1/dictionaries/%s/batch", d)),
+			httpmock.JSONResponse(search.UpdatedAtResponse{TaskID: int64((i + 1) * 100)}),
+		)
+	}
+
+	f, out := test.NewFactory(false, &r, nil, "")
+	cmd := NewClearCmd(f, nil)
+	out, err := test.Execute(cmd, "plurals compounds --confirm --output json", out)
+	require.NoError(t, err)
+
+	var got []search.UpdatedAtResponse
+	require.NoError(t, json.Unmarshal([]byte(out.String()), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, int64(100), got[0].TaskID)
+	assert.Equal(t, int64(200), got[1].TaskID)
 }

--- a/pkg/cmd/dictionary/settings/set/set.go
+++ b/pkg/cmd/dictionary/settings/set/set.go
@@ -21,6 +21,8 @@ type SetOptions struct {
 	DisableStandardEntries []string
 	EnableStandardEntries  []string
 	ResetStandardEntries   bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewSetCmd creates and returns a set command for dictionaries' settings.
@@ -29,6 +31,7 @@ func NewSetCmd(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 	cmd := &cobra.Command{
 		Use:  "set --disable-standard-entries <languages...>  --enable-standard-entries <languages...> [--reset-standard-entries]",
@@ -112,6 +115,8 @@ func NewSetCmd(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 		cmdutil.StringCompletionFunc(supportedLanguages),
 	)
 
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -158,6 +163,14 @@ func runSetCmd(opts *SetOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, res)
+	}
 
 	cs := opts.IO.ColorScheme()
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/indices/clear/clear.go
+++ b/pkg/cmd/indices/clear/clear.go
@@ -23,6 +23,8 @@ type ClearOptions struct {
 	Index     string
 	DoConfirm bool
 	Wait      bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewClearCmd creates and returns a clear command for indices
@@ -31,6 +33,7 @@ func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Comm
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 
 	var confirm bool
@@ -72,6 +75,8 @@ func NewClearCmd(f *cmdutil.Factory, runF func(*ClearOptions) error) *cobra.Comm
 
 	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "Wait for the operation to complete")
+
+	opts.PrintFlags.AddFlags(cmd)
 
 	return cmd
 }
@@ -115,6 +120,14 @@ func runClearCmd(opts *ClearOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, res)
+	}
 
 	cs := opts.IO.ColorScheme()
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/indices/copy/copy.go
+++ b/pkg/cmd/indices/copy/copy.go
@@ -29,6 +29,8 @@ type CopyOptions struct {
 	Wait bool
 
 	DoConfirm bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewCopyCmd creates and returns a copy command for indices
@@ -37,6 +39,7 @@ func NewCopyCmd(f *cmdutil.Factory, runF func(*CopyOptions) error) *cobra.Comman
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 
 	var confirm bool
@@ -100,6 +103,8 @@ func NewCopyCmd(f *cmdutil.Factory, runF func(*CopyOptions) error) *cobra.Comman
 			"synonyms": "synonyms",
 			"rules":    "rules",
 		}, "copy"))
+
+	opts.PrintFlags.AddFlags(cmd)
 
 	return cmd
 }
@@ -173,6 +178,14 @@ func runCopyCmd(opts *CopyOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, res)
+	}
 
 	cs := opts.IO.ColorScheme()
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/indices/move/move.go
+++ b/pkg/cmd/indices/move/move.go
@@ -27,6 +27,8 @@ type MoveOptions struct {
 	Wait bool
 
 	DoConfirm bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewMoveCmd creates and returns a move command for indices
@@ -35,6 +37,7 @@ func NewMoveCmd(f *cmdutil.Factory, runF func(*MoveOptions) error) *cobra.Comman
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 
 	var confirm bool
@@ -77,6 +80,8 @@ func NewMoveCmd(f *cmdutil.Factory, runF func(*MoveOptions) error) *cobra.Comman
 
 	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "Skip the move index confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "Wait for the operation to complete")
+
+	opts.PrintFlags.AddFlags(cmd)
 
 	return cmd
 }
@@ -135,6 +140,14 @@ func runMoveCmd(opts *MoveOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, res)
+	}
 
 	if opts.IO.IsStdoutTTY() {
 		fmt.Fprintf(

--- a/pkg/cmd/objects/import/import.go
+++ b/pkg/cmd/objects/import/import.go
@@ -26,6 +26,8 @@ type ImportOptions struct {
 	BatchSize     int
 	AutoObjectIDs bool
 	Wait          bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewImportCmd creates and returns an import command for records
@@ -34,6 +36,7 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 
 	var file string
@@ -79,6 +82,9 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().
 		BoolVarP(&opts.AutoObjectIDs, "auto-generate-object-id-if-not-exist", "a", false, "Auto-generate object IDs if they don't exist")
 	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "wait for the operation to complete")
+
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -144,6 +150,14 @@ func runImportCmd(opts *ImportOptions) error {
 
 	if err := opts.Scanner.Err(); err != nil {
 		return err
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, responses)
 	}
 
 	cs := opts.IO.ColorScheme()

--- a/pkg/cmd/rules/delete/delete.go
+++ b/pkg/cmd/rules/delete/delete.go
@@ -28,6 +28,8 @@ type DeleteOptions struct {
 	Wait              bool
 
 	DoConfirm bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewDeleteCmd creates and returns a delete command for index rules
@@ -38,6 +40,7 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 
 	cmd := &cobra.Command{
@@ -85,6 +88,8 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "Wait for the operation to complete")
 
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -123,7 +128,7 @@ func runDeleteCmd(opts *DeleteOptions) error {
 		}
 	}
 
-	var taskIDs []int64
+	responses := make([]search.UpdatedAtResponse, 0, len(opts.RuleIDs))
 
 	for _, ruleID := range opts.RuleIDs {
 		res, err := client.DeleteRule(
@@ -133,18 +138,23 @@ func runDeleteCmd(opts *DeleteOptions) error {
 		if err != nil {
 			return fmt.Errorf("failed to delete rule %s: %w", ruleID, err)
 		}
-		if opts.Wait {
-			taskIDs = append(taskIDs, res.TaskID)
-		}
+		responses = append(responses, *res)
 	}
 
-	if len(taskIDs) > 0 {
-		for _, taskID := range taskIDs {
-			_, err := client.WaitForTask(opts.Index, taskID)
-			if err != nil {
+	if opts.Wait {
+		for _, res := range responses {
+			if _, err := client.WaitForTask(opts.Index, res.TaskID); err != nil {
 				return err
 			}
 		}
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, responses)
 	}
 
 	cs := opts.IO.ColorScheme()

--- a/pkg/cmd/rules/delete/delete_test.go
+++ b/pkg/cmd/rules/delete/delete_test.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -195,4 +196,32 @@ func Test_runDeleteCmd(t *testing.T) {
 			assert.Equal(t, tt.wantOut, out.String())
 		})
 	}
+}
+
+// Test_runDeleteCmd_outputJSON checks that the --output json path emits every
+// delete response, in order — i.e. the multi-id collection loop, not the printer.
+func Test_runDeleteCmd_outputJSON(t *testing.T) {
+	r := httpmock.Registry{}
+	ids := []string{"1", "2"}
+	for i, id := range ids {
+		r.Register(
+			httpmock.REST("GET", fmt.Sprintf("1/indexes/foo/rules/%s", id)),
+			httpmock.JSONResponse(search.SearchRulesResponse{}),
+		)
+		r.Register(
+			httpmock.REST("DELETE", fmt.Sprintf("1/indexes/foo/rules/%s", id)),
+			httpmock.JSONResponse(search.UpdatedAtResponse{TaskID: int64((i + 1) * 100)}),
+		)
+	}
+
+	f, out := test.NewFactory(false, &r, nil, "")
+	cmd := NewDeleteCmd(f, nil)
+	out, err := test.Execute(cmd, "foo --rule-ids 1,2 --confirm --output json", out)
+	require.NoError(t, err)
+
+	var got []search.UpdatedAtResponse
+	require.NoError(t, json.Unmarshal([]byte(out.String()), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, int64(100), got[0].TaskID)
+	assert.Equal(t, int64(200), got[1].TaskID)
 }

--- a/pkg/cmd/settings/import/import.go
+++ b/pkg/cmd/settings/import/import.go
@@ -24,6 +24,8 @@ type ImportOptions struct {
 	Settings          search.IndexSettings
 	ForwardToReplicas bool
 	Wait              bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewImportCmd creates and returns an import command for settings
@@ -32,6 +34,7 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 
 	var settingsFile string
@@ -68,6 +71,8 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		BoolVarP(&opts.ForwardToReplicas, "forward-to-replicas", "f", false, "Forward the settings to the replicas")
 	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "wait for the operation to complete")
 
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -97,6 +102,14 @@ func runImportCmd(opts *ImportOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, res)
+	}
 
 	cs := opts.IO.ColorScheme()
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/settings/set/set.go
+++ b/pkg/cmd/settings/set/set.go
@@ -25,6 +25,8 @@ type SetOptions struct {
 	Wait              bool
 
 	Index string
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewSetCmd creates and returns a set command for settings
@@ -33,6 +35,7 @@ func NewSetCmd(f *cmdutil.Factory) *cobra.Command {
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 	cmd := &cobra.Command{
 		Use:  "set <index>",
@@ -74,6 +77,8 @@ func NewSetCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmdutil.AddIndexSettingsFlags(cmd)
 
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -106,6 +111,14 @@ func runSetCmd(opts *SetOptions) error {
 	}
 
 	opts.IO.StopProgressIndicator()
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, res)
+	}
 
 	cs := opts.IO.ColorScheme()
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/synonyms/delete/delete.go
+++ b/pkg/cmd/synonyms/delete/delete.go
@@ -28,6 +28,8 @@ type DeleteOptions struct {
 	Wait              bool
 
 	DoConfirm bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewDeleteCmd creates and returns a delete command for index synonyms
@@ -38,6 +40,7 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 
 	cmd := &cobra.Command{
@@ -85,6 +88,8 @@ func NewDeleteCmd(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "Wait for the operation to complete")
 
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -124,7 +129,7 @@ func runDeleteCmd(opts *DeleteOptions) error {
 		}
 	}
 
-	var taskIDs []int64
+	responses := make([]search.DeletedAtResponse, 0, len(opts.SynonymIDs))
 
 	for _, synonymID := range opts.SynonymIDs {
 		res, err := client.DeleteSynonym(
@@ -134,18 +139,23 @@ func runDeleteCmd(opts *DeleteOptions) error {
 		if err != nil {
 			return fmt.Errorf("failed to delete synonym %s: %w", synonymID, err)
 		}
-		if opts.Wait {
-			taskIDs = append(taskIDs, res.TaskID)
-		}
+		responses = append(responses, *res)
 	}
 
-	if len(taskIDs) > 0 {
-		for _, taskID := range taskIDs {
-			_, err := client.WaitForTask(opts.Index, taskID)
-			if err != nil {
+	if opts.Wait {
+		for _, res := range responses {
+			if _, err := client.WaitForTask(opts.Index, res.TaskID); err != nil {
 				return err
 			}
 		}
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, responses)
 	}
 
 	cs := opts.IO.ColorScheme()

--- a/pkg/cmd/synonyms/delete/delete_test.go
+++ b/pkg/cmd/synonyms/delete/delete_test.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -198,4 +199,35 @@ func Test_runDeleteCmd(t *testing.T) {
 			assert.Equal(t, tt.wantOut, out.String())
 		})
 	}
+}
+
+// Test_runDeleteCmd_outputJSON checks that the --output json path emits every
+// delete response, in order — i.e. the multi-id collection loop, not the printer.
+func Test_runDeleteCmd_outputJSON(t *testing.T) {
+	r := httpmock.Registry{}
+	ids := []string{"1", "2"}
+	for i, id := range ids {
+		r.Register(
+			httpmock.REST("GET", fmt.Sprintf("1/indexes/foo/synonyms/%s", id)),
+			httpmock.JSONResponse(search.SynonymHit{
+				ObjectID: id,
+				Type:     search.SYNONYM_TYPE_ONEWAYSYNONYM,
+			}),
+		)
+		r.Register(
+			httpmock.REST("DELETE", fmt.Sprintf("1/indexes/foo/synonyms/%s", id)),
+			httpmock.JSONResponse(search.DeletedAtResponse{TaskID: int64((i + 1) * 100)}),
+		)
+	}
+
+	f, out := test.NewFactory(false, &r, nil, "")
+	cmd := NewDeleteCmd(f, nil)
+	out, err := test.Execute(cmd, "foo --synonym-ids 1,2 --confirm --output json", out)
+	require.NoError(t, err)
+
+	var got []search.DeletedAtResponse
+	require.NoError(t, json.Unmarshal([]byte(out.String()), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, int64(100), got[0].TaskID)
+	assert.Equal(t, int64(200), got[1].TaskID)
 }

--- a/pkg/cmd/synonyms/save/save.go
+++ b/pkg/cmd/synonyms/save/save.go
@@ -26,6 +26,8 @@ type SaveOptions struct {
 	Synonym           search.SynonymHit
 	SuccessMessage    string
 	Wait              bool
+
+	PrintFlags *cmdutil.PrintFlags
 }
 
 // NewSaveCmd creates and returns a save command for index synonyms
@@ -34,6 +36,7 @@ func NewSaveCmd(f *cmdutil.Factory, runF func(*SaveOptions) error) *cobra.Comman
 		IO:           f.IOStreams,
 		Config:       f.Config,
 		SearchClient: f.SearchClient,
+		PrintFlags:   cmdutil.NewPrintFlags(),
 	}
 
 	flags := &shared.SynonymFlags{}
@@ -123,6 +126,8 @@ func NewSaveCmd(f *cmdutil.Factory, runF func(*SaveOptions) error) *cobra.Comman
 		StringSliceVarP(&flags.SynonymCorrections, "corrections", "c", nil, "A list of corrections of the word (alt correction synonyms only)")
 	cmd.Flags().BoolVarP(&opts.Wait, "wait", "", false, "Wait for the operation to complete")
 
+	opts.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
@@ -143,6 +148,14 @@ func runSaveCmd(opts *SaveOptions) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
+		p, err := opts.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+		return p.Print(opts.IO, res)
 	}
 
 	if opts.IO.IsStdoutTTY() {


### PR DESCRIPTION
## What

- Add the `--output`/`-o` output formatting flags to the commands that were missing them.
- When `-o` is passed, the command prints its API response as structured output; the default human-readable output is unchanged.

## Test

Check that `-o json` works and that the default output is unchanged on any updated command, like
```
algolia synonyms save
algolia synonyms delete
algolia rules delete
algolia settings import
```

- `algolia describe <command>` surfaces the "Output formatting flags" group for each of the above.

[GROUT-348]

[GROUT-348]: https://algolia.atlassian.net/browse/GROUT-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ