### PR TITLE
feat: add auth get command

### DIFF
--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/algolia/cli/pkg/auth"
 	"github.com/algolia/cli/pkg/cmd/auth/crawler"
+	"github.com/algolia/cli/pkg/cmd/auth/get"
 	"github.com/algolia/cli/pkg/cmd/auth/login"
 	"github.com/algolia/cli/pkg/cmd/auth/logout"
 	"github.com/algolia/cli/pkg/cmd/auth/signup"
@@ -22,6 +23,7 @@ func NewAuthCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.AddCommand(login.NewLoginCmd(f))
 	cmd.AddCommand(logout.NewLogoutCmd(f))
+	cmd.AddCommand(get.NewGetCmd(f))
 	cmd.AddCommand(signup.NewSignupCmd(f))
 	cmd.AddCommand(crawler.NewCrawlerCmd(f))
 

--- a/pkg/cmd/auth/get/get.go
+++ b/pkg/cmd/auth/get/get.go
@@ -1,0 +1,84 @@
+package get
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+// GetOptions represents the options for the get command.
+type GetOptions struct {
+	IO *iostreams.IOStreams
+
+	LoadToken func() *auth.StoredToken
+
+	PrintFlags *cmdutil.PrintFlags
+}
+
+// Identity is the authenticated user, without any token information.
+type Identity struct {
+	UserID string `json:"user_id,omitempty"`
+	Email  string `json:"email,omitempty"`
+	Name   string `json:"name,omitempty"`
+}
+
+// NewGetCmd returns a new instance of the get command.
+func NewGetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &GetOptions{
+		IO:         f.IOStreams,
+		LoadToken:  auth.LoadToken,
+		PrintFlags: cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get the authenticated user",
+		Long: heredoc.Doc(`
+			Get the identity of the authenticated user from the OAuth
+			credentials stored in the local keychain.
+		`),
+		Example: heredoc.Doc(`
+			# Get the authenticated user
+			$ algolia auth get
+		`),
+		Args: validators.NoArgs(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGetCmd(opts)
+		},
+	}
+
+	opts.PrintFlags.AddFlags(cmd)
+
+	return cmd
+}
+
+// runGetCmd runs the get command.
+func runGetCmd(opts *GetOptions) error {
+	stored := opts.LoadToken()
+	if stored == nil {
+		return fmt.Errorf("you are not logged in — run `algolia auth login` first")
+	}
+
+	if stored.IsExpired() {
+		return fmt.Errorf("your session has expired — run `algolia auth login` again")
+	}
+
+	identity := Identity{
+		UserID: stored.UserID,
+		Email:  stored.Email,
+		Name:   stored.Name,
+	}
+
+	p, err := opts.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	return p.Print(opts.IO, identity)
+}

--- a/pkg/cmd/auth/get/get_test.go
+++ b/pkg/cmd/auth/get/get_test.go
@@ -1,0 +1,75 @@
+package get
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/test"
+)
+
+func TestGet_NotLoggedIn(t *testing.T) {
+	keyring.MockInit()
+	auth.ClearToken()
+
+	f, out := test.NewFactory(false, nil, nil, "")
+	cmd := NewGetCmd(f)
+	_, err := test.Execute(cmd, "", out)
+	require.Error(t, err)
+	assert.Equal(t, "you are not logged in — run `algolia auth login` first", err.Error())
+}
+
+func TestGet_Expired(t *testing.T) {
+	keyring.MockInit()
+	t.Cleanup(auth.ClearToken)
+	require.NoError(t, auth.SaveToken(&dashboard.OAuthTokenResponse{
+		AccessToken: "secret-access",
+		CreatedAt:   time.Now().Unix() - 7200,
+		ExpiresIn:   3600,
+		User: &dashboard.User{
+			ID:    42,
+			Email: "user@example.com",
+			Name:  "Test User",
+		},
+	}))
+
+	f, out := test.NewFactory(false, nil, nil, "")
+	cmd := NewGetCmd(f)
+	_, err := test.Execute(cmd, "", out)
+	require.Error(t, err)
+	assert.Equal(t, "your session has expired — run `algolia auth login` again", err.Error())
+}
+
+func TestGet_PrintsIdentityWithoutTokens(t *testing.T) {
+	keyring.MockInit()
+	t.Cleanup(auth.ClearToken)
+	require.NoError(t, auth.SaveToken(&dashboard.OAuthTokenResponse{
+		AccessToken:  "secret-access",
+		RefreshToken: "secret-refresh",
+		CreatedAt:    time.Now().Unix(),
+		ExpiresIn:    3600,
+		User: &dashboard.User{
+			ID:    42,
+			Email: "user@example.com",
+			Name:  "Test User",
+		},
+	}))
+
+	f, out := test.NewFactory(false, nil, nil, "")
+	cmd := NewGetCmd(f)
+	out, err := test.Execute(cmd, "--output ndjson", out)
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), `"user_id":"42"`)
+	assert.Contains(t, out.String(), `"email":"user@example.com"`)
+	assert.Contains(t, out.String(), `"name":"Test User"`)
+	assert.NotContains(t, out.String(), "secret-access")
+	assert.NotContains(t, out.String(), "secret-refresh")
+	assert.NotContains(t, out.String(), "access_token")
+	assert.NotContains(t, out.String(), "refresh_token")
+}


### PR DESCRIPTION
- Adds `auth get` which returns the identity of the user, but not any token info

Testing:
- Build from source, install the cli, run `algolia auth get` and see that you get a json object of your identity info
- Try, but logged out, and see that you get an error message