### PR TITLE
feat(application): prompt for application name on after signup

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -153,9 +153,18 @@ func runOAuthFlowSteps(
 		fmt.Fprintf(opts.IO.Out, "\n%s No applications found. Let's create one.\n", cs.WarningIcon())
 
 		tracker.SetStep(telemetry.StepAppCreate)
+
+		appName := opts.AppName
+		if appName == "" && opts.IO.CanPrompt() {
+			appName, err = apputil.PromptName()
+			if err != nil {
+				return err
+			}
+		}
+
 		// No create tracker: this creation belongs to the auth funnel, which
 		// stays on the app_create step.
-		appDetails, _, err = apputil.CreateAndFetchApplication(opts.IO, client, accessToken, "", opts.AppName, nil)
+		appDetails, _, err = apputil.CreateAndFetchApplication(opts.IO, client, accessToken, "", appName, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/shared/apputil/create.go
+++ b/pkg/cmd/shared/apputil/create.go
@@ -108,6 +108,28 @@ func PromptRegion(
 	return regions[selected].Code, nil
 }
 
+// PromptName prompts the user for the application name.
+func PromptName() (string, error) {
+	defaultName := "My First Application"
+
+	var name string
+	err := prompt.SurveyAskOne(
+		&survey.Input{
+			Message: "Name:",
+			Default: defaultName,
+		},
+		&name,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if name == "" {
+		name = defaultName
+	}
+	return name, nil
+}
+
 // CreateAndFetchApplication creates an application (with region retry) and
 // generates an API key for it. It returns the region the application was
 // actually created in, which may differ from the requested one.

--- a/pkg/cmd/shared/apputil/create_test.go
+++ b/pkg/cmd/shared/apputil/create_test.go
@@ -3,6 +3,7 @@ package apputil
 import (
 	"testing"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/go-keyring"
@@ -11,6 +12,7 @@ import (
 	"github.com/algolia/cli/pkg/config"
 	"github.com/algolia/cli/pkg/iostreams"
 	"github.com/algolia/cli/pkg/keychain"
+	"github.com/algolia/cli/pkg/prompt"
 	"github.com/algolia/cli/test"
 )
 
@@ -49,6 +51,34 @@ func TestConfigureProfile_AliasCollisionDerivesUniqueAlias(t *testing.T) {
 	require.NoError(t, ConfigureProfile(io, cfg, app, "", true))
 
 	assert.Equal(t, "my app-app1", cfg.SavedApps["APP1"].Alias)
+}
+
+func TestPromptName(t *testing.T) {
+	t.Run("returns entered value", func(t *testing.T) {
+		origAsk := prompt.SurveyAskOne
+		prompt.SurveyAskOne = func(_ survey.Prompt, response interface{}, _ ...survey.AskOpt) error {
+			*(response.(*string)) = "Typed Name"
+			return nil
+		}
+		t.Cleanup(func() { prompt.SurveyAskOne = origAsk })
+
+		name, err := PromptName()
+		require.NoError(t, err)
+		assert.Equal(t, "Typed Name", name)
+	})
+
+	t.Run("empty input falls back to default", func(t *testing.T) {
+		origAsk := prompt.SurveyAskOne
+		prompt.SurveyAskOne = func(_ survey.Prompt, response interface{}, _ ...survey.AskOpt) error {
+			*(response.(*string)) = ""
+			return nil
+		}
+		t.Cleanup(func() { prompt.SurveyAskOne = origAsk })
+
+		name, err := PromptName()
+		require.NoError(t, err)
+		assert.Equal(t, "My First Application", name)
+	})
 }
 
 func TestReuseExistingAPIKey_FromKeychain(t *testing.T) {


### PR DESCRIPTION
After `algolia auth signup` is complete, it automatically prompts the user to create an application. Until now, it wouldn't let the user pick a name for the app, nor give a default value. This PR aims to fix both.