### PR TITLE
feat(auth): add --region flag to signup and login

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -26,6 +26,7 @@ type LoginOptions struct {
 
 	AppName     string
 	ProfileName string
+	Region      string
 	Default     bool
 
 	// NoBrowser disables automatic browser opening; the authorize URL is
@@ -78,6 +79,8 @@ func NewLoginCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.AppName, "app-name", "", "Auto-select application by name")
+	cmd.Flags().
+		StringVar(&opts.Region, "region", "", "Region for the first application when the account has none (e.g. EU, UK, USC, USE, USW)")
 	cmd.Flags().StringVar(&opts.ProfileName, "profile-name", "", "Alias for the application (defaults to the application name)")
 	cmd.Flags().BoolVar(&opts.Default, "default", true, "Set the application as the current one")
 	cmd.Flags().BoolVar(&opts.NoBrowser, "no-browser", false, "Print the authorize URL instead of opening the browser")
@@ -164,7 +167,7 @@ func runOAuthFlowSteps(
 
 		// No create tracker: this creation belongs to the auth funnel, which
 		// stays on the app_create step.
-		appDetails, _, err = apputil.CreateAndFetchApplication(opts.IO, client, accessToken, "", appName, nil)
+		appDetails, _, err = apputil.CreateAndFetchApplication(opts.IO, client, accessToken, opts.Region, appName, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/auth/signup/signup.go
+++ b/pkg/cmd/auth/signup/signup.go
@@ -39,6 +39,8 @@ func NewSignupCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.AppName, "app-name", "", "Name for the first application")
+	cmd.Flags().
+		StringVar(&opts.Region, "region", "", "Region for the first application (e.g. EU, UK, USC, USE, USW)")
 	cmd.Flags().StringVar(&opts.ProfileName, "profile-name", "", "Alias for the application (defaults to the application name)")
 	cmd.Flags().BoolVar(&opts.Default, "default", true, "Set the application as the current one")
 	cmd.Flags().BoolVar(&opts.NoBrowser, "no-browser", false, "Print the authorize URL instead of opening the browser")

--- a/pkg/cmd/shared/apputil/create.go
+++ b/pkg/cmd/shared/apputil/create.go
@@ -32,6 +32,11 @@ func CreateApplicationWithRetry(
 
 	for {
 		if region == "" {
+			if !io.CanPrompt() {
+				return nil, "", fmt.Errorf(
+					"no region specified; pass --region (e.g. EU, UK, USC, USE, USW)",
+				)
+			}
 			tracker.SetStep(telemetry.StepRegion)
 			var err error
 			region, err = PromptRegion(io, client, accessToken)

--- a/pkg/cmd/shared/apputil/create_test.go
+++ b/pkg/cmd/shared/apputil/create_test.go
@@ -1,6 +1,9 @@
 package apputil
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -79,6 +82,38 @@ func TestPromptName(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "My First Application", name)
 	})
+}
+
+func TestCreateApplicationWithRetry_PassesRegionNonInteractive(t *testing.T) {
+	var got dashboard.CreateApplicationRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1/applications", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		require.NoError(t, json.NewEncoder(w).Encode(dashboard.SingleApplicationResponse{
+			Data: dashboard.ApplicationResource{
+				ID:   "APP1",
+				Type: "application",
+				Attributes: dashboard.ApplicationAttributes{
+					ApplicationID: "APP1",
+					Name:          "My App",
+				},
+			},
+		}))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := dashboard.NewClientWithHTTPClient("test", srv.Client())
+	client.APIURL = srv.URL
+
+	io, _, _, _ := iostreams.Test()
+	app, region, err := CreateApplicationWithRetry(io, client, "token", "EU", "My App", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "EU", got.RegionCode)
+	assert.Equal(t, "My App", got.Name)
+	assert.Equal(t, "EU", region)
+	assert.Equal(t, "APP1", app.ID)
 }
 
 func TestCreateApplicationWithRetry_NonInteractiveRequiresRegion(t *testing.T) {

--- a/pkg/cmd/shared/apputil/create_test.go
+++ b/pkg/cmd/shared/apputil/create_test.go
@@ -81,6 +81,17 @@ func TestPromptName(t *testing.T) {
 	})
 }
 
+func TestCreateApplicationWithRetry_NonInteractiveRequiresRegion(t *testing.T) {
+	io, _, _, _ := iostreams.Test()
+
+	app, region, err := CreateApplicationWithRetry(io, nil, "token", "", "My App", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--region")
+	assert.Nil(t, app)
+	assert.Empty(t, region)
+}
+
 func TestReuseExistingAPIKey_FromKeychain(t *testing.T) {
 	keyring.MockInit()
 	require.NoError(t, keychain.SaveAppSecrets("APP1",


### PR DESCRIPTION
## What

- `auth signup` and `auth login` accept `--region` for the first application created when the account has none.
- When no region is given and the CLI can't prompt (no TTY), the region picker is replaced by an actionable error — `no region specified; pass --region (e.g. EU, UK, USC, USE, USW)` — instead of dying on EOF. Makes sign-up completable from scripts and agents.

## Test

```sh
algolia auth signup --help          # --region listed
algolia auth login --help           # --region listed
algolia auth signup --app-name "Demo" --region EU   # on a fresh account: first app created in EU, no region prompt
```