### PR TITLE
feat(auth): add read-only auth status command

### DIFF
--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/algolia/cli/pkg/cmd/auth/login"
 	"github.com/algolia/cli/pkg/cmd/auth/logout"
 	"github.com/algolia/cli/pkg/cmd/auth/signup"
+	"github.com/algolia/cli/pkg/cmd/auth/status"
 	"github.com/algolia/cli/pkg/cmdutil"
 )
 
@@ -16,7 +17,7 @@ import (
 func NewAuthCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
-		Short: "Authenticate with your Algolia account",
+		Short: "Sign up, log in and out, and check authentication status",
 	}
 
 	auth.DisableAuthCheck(cmd)
@@ -25,6 +26,7 @@ func NewAuthCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(logout.NewLogoutCmd(f))
 	cmd.AddCommand(get.NewGetCmd(f))
 	cmd.AddCommand(signup.NewSignupCmd(f))
+	cmd.AddCommand(status.NewStatusCmd(f))
 	cmd.AddCommand(crawler.NewCrawlerCmd(f))
 
 	return cmd

--- a/pkg/cmd/auth/get/get.go
+++ b/pkg/cmd/auth/get/get.go
@@ -1,6 +1,8 @@
 package get
 
 import (
+	"fmt"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
@@ -73,6 +75,11 @@ func runGetCmd(opts *GetOptions) error {
 	}
 
 	stored := opts.LoadToken()
+	if stored == nil {
+		return fmt.Errorf(
+			"authentication succeeded, but the token could not be read back from the OS keychain; credentials were not persisted",
+		)
+	}
 
 	identity := Identity{
 		UserID: stored.UserID,

--- a/pkg/cmd/auth/get/get_test.go
+++ b/pkg/cmd/auth/get/get_test.go
@@ -94,6 +94,23 @@ func TestGet_ReturnsErrorWhenLoginFails(t *testing.T) {
 	assert.Equal(t, "authorization failed: access_denied", err.Error())
 }
 
+func TestGet_ErrorsWhenTokenNotPersisted(t *testing.T) {
+	f, out := test.NewFactory(false, nil, nil, "")
+	opts := &GetOptions{
+		IO:                 f.IOStreams,
+		LoadToken:          func() *auth.StoredToken { return nil },
+		PrintFlags:         cmdutil.NewPrintFlags().WithDefaultOutput("json"),
+		NewDashboardClient: func(clientID string) *dashboard.Client { return nil },
+		EnsureAuthenticated: func(_ *iostreams.IOStreams, _ *dashboard.Client) (string, error) {
+			return "in-memory-token", nil
+		},
+	}
+
+	_, err := test.Execute(cmdWithOpts(opts), "", out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "keychain")
+}
+
 func TestGet_RefreshesExpiredToken(t *testing.T) {
 	keyring.MockInit()
 	t.Cleanup(auth.ClearToken)

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -1,0 +1,149 @@
+package status
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/config"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/pkg/validators"
+)
+
+type StatusOptions struct {
+	IO        *iostreams.IOStreams
+	Config    config.IConfig
+	LoadToken func() *auth.StoredToken
+}
+
+func NewStatusCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &StatusOptions{
+		IO:        f.IOStreams,
+		Config:    f.Config,
+		LoadToken: auth.LoadToken,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show authentication and configuration status",
+		Long: heredoc.Doc(`
+			Show whether you're signed in, which application is current, and
+			whether API credentials are available.
+
+			This command is read-only: it never prompts, opens a browser, or
+			modifies stored credentials. It exits with a non-zero status when
+			no usable credentials are found.
+		`),
+		Example: heredoc.Doc(`
+			# Check the authentication status
+			$ algolia auth status
+		`),
+		Args: validators.NoArgs(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatusCmd(opts)
+		},
+	}
+
+	return cmd
+}
+
+func runStatusCmd(opts *StatusOptions) error {
+	cs := opts.IO.ColorScheme()
+	out := opts.IO.Out
+
+	sessionOK := false
+	token := opts.LoadToken()
+	switch {
+	case token == nil:
+		fmt.Fprintf(out, "%s Not signed in\n", cs.FailureIcon())
+	case token.IsExpired() && token.RefreshToken == "":
+		fmt.Fprintf(
+			out,
+			"%s Session expired for %s — run `algolia auth login` to sign in again\n",
+			cs.FailureIcon(),
+			cs.Bold(token.Email),
+		)
+	default:
+		sessionOK = true
+		who := token.Email
+		if who == "" {
+			who = token.UserID
+		}
+		fmt.Fprintf(out, "%s Signed in as %s\n", cs.SuccessIcon(), cs.Bold(who))
+		if token.IsExpired() {
+			fmt.Fprintf(
+				out,
+				"%s Access token expired; it refreshes automatically on the next command\n",
+				cs.WarningIcon(),
+			)
+		}
+	}
+
+	appID, appErr := opts.Config.Profile().GetApplicationID()
+	credentialsOK := false
+	if appErr != nil {
+		fmt.Fprintf(
+			out,
+			"%s No application selected — run `algolia application select`, or set ALGOLIA_APPLICATION_ID\n",
+			cs.WarningIcon(),
+		)
+	} else {
+		fmt.Fprintf(out, "%s Current application: %s\n", cs.SuccessIcon(), cs.Bold(appID))
+		if _, keyErr := opts.Config.Profile().GetAPIKey(); keyErr != nil {
+			fmt.Fprintf(out, "%s No API key available: %s\n", cs.WarningIcon(), keyErr)
+		} else {
+			credentialsOK = true
+			fmt.Fprintf(out, "%s API key: available\n", cs.SuccessIcon())
+		}
+	}
+
+	printEnvOverrides(opts.IO)
+
+	if !sessionOK && !credentialsOK {
+		fmt.Fprintf(
+			out,
+			"\nRun `algolia auth login` to sign in, or set ALGOLIA_APPLICATION_ID and ALGOLIA_API_KEY.\n",
+		)
+		return cmdutil.ErrSilent
+	}
+	return nil
+}
+
+func printEnvOverrides(io *iostreams.IOStreams) {
+	cs := io.ColorScheme()
+
+	if v := os.Getenv("ALGOLIA_APPLICATION_ID"); v != "" {
+		fmt.Fprintf(
+			io.Out,
+			"%s ALGOLIA_APPLICATION_ID is set (%s) — it takes precedence over the selected application\n",
+			cs.WarningIcon(),
+			v,
+		)
+	}
+	if os.Getenv("ALGOLIA_API_KEY") != "" {
+		fmt.Fprintf(
+			io.Out,
+			"%s ALGOLIA_API_KEY is set — it takes precedence over the stored API key\n",
+			cs.WarningIcon(),
+		)
+	}
+	if os.Getenv("ALGOLIA_ADMIN_API_KEY") != "" {
+		fmt.Fprintf(
+			io.Out,
+			"%s ALGOLIA_ADMIN_API_KEY is set (deprecated) — use ALGOLIA_API_KEY instead\n",
+			cs.WarningIcon(),
+		)
+	}
+	if v := os.Getenv("ALGOLIA_SEARCH_HOSTS"); v != "" {
+		fmt.Fprintf(
+			io.Out,
+			"%s ALGOLIA_SEARCH_HOSTS is set — API requests go to: %s\n",
+			cs.WarningIcon(),
+			v,
+		)
+	}
+}

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -36,7 +36,7 @@ func NewStatusCmd(f *cmdutil.Factory) *cobra.Command {
 
 			This command is read-only: it never prompts, opens a browser, or
 			modifies stored credentials. It exits with a non-zero status when
-			no usable credentials are found.
+			neither a session nor API credentials are found.
 		`),
 		Example: heredoc.Doc(`
 			# Check the authentication status

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -1,0 +1,136 @@
+package status
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+
+	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmdutil"
+	"github.com/algolia/cli/pkg/iostreams"
+	"github.com/algolia/cli/test"
+)
+
+func clearEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{
+		"ALGOLIA_APPLICATION_ID",
+		"ALGOLIA_API_KEY",
+		"ALGOLIA_ADMIN_API_KEY",
+		"ALGOLIA_SEARCH_HOSTS",
+	} {
+		t.Setenv(v, "")
+	}
+}
+
+func newTestOpts(cfg *test.ConfigStub, token *auth.StoredToken) (*StatusOptions, *iostreams.IOStreams, func() string) {
+	io, _, out, _ := iostreams.Test()
+	opts := &StatusOptions{
+		IO:        io,
+		Config:    cfg,
+		LoadToken: func() *auth.StoredToken { return token },
+	}
+	return opts, io, out.String
+}
+
+func TestStatus_NotSignedInNoCredentials(t *testing.T) {
+	clearEnv(t)
+	opts, _, out := newTestOpts(&test.ConfigStub{}, nil)
+
+	err := runStatusCmd(opts)
+
+	require.ErrorIs(t, err, cmdutil.ErrSilent)
+	assert.Contains(t, out(), "Not signed in")
+	assert.Contains(t, out(), "No application selected")
+	assert.Contains(t, out(), "algolia auth login")
+}
+
+func TestStatus_SignedInWithApplicationAndKey(t *testing.T) {
+	clearEnv(t)
+	cfg := test.NewDefaultConfigStub()
+	cfg.CurrentProfile.ApplicationID = "APP1"
+	cfg.CurrentProfile.APIKey = "key-1"
+	token := &auth.StoredToken{
+		AccessToken: "access",
+		ExpiresAt:   time.Now().Unix() + 3600,
+		Email:       "user@example.com",
+	}
+	opts, _, out := newTestOpts(cfg, token)
+
+	err := runStatusCmd(opts)
+
+	require.NoError(t, err)
+	assert.Contains(t, out(), "Signed in as user@example.com")
+	assert.Contains(t, out(), "Current application: APP1")
+	assert.Contains(t, out(), "API key: available")
+	assert.NotContains(t, out(), "key-1")
+}
+
+func TestStatus_ExpiredSessionWithoutRefreshToken(t *testing.T) {
+	clearEnv(t)
+	token := &auth.StoredToken{
+		AccessToken: "access",
+		ExpiresAt:   time.Now().Unix() - 3600,
+		Email:       "user@example.com",
+	}
+	opts, _, out := newTestOpts(&test.ConfigStub{}, token)
+
+	err := runStatusCmd(opts)
+
+	require.ErrorIs(t, err, cmdutil.ErrSilent)
+	assert.Contains(t, out(), "Session expired")
+}
+
+func TestStatus_EnvCredentialsWithoutSession(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("ALGOLIA_APPLICATION_ID", "ENVAPP")
+	t.Setenv("ALGOLIA_API_KEY", "env-key")
+	t.Setenv("ALGOLIA_SEARCH_HOSTS", "c1-test-1.algolianet.com")
+	opts, _, out := newTestOpts(&test.ConfigStub{}, nil)
+
+	err := runStatusCmd(opts)
+
+	require.NoError(t, err)
+	assert.Contains(t, out(), "Not signed in")
+	assert.Contains(t, out(), "Current application: ENVAPP")
+	assert.Contains(t, out(), "ALGOLIA_APPLICATION_ID is set")
+	assert.Contains(t, out(), "ALGOLIA_API_KEY is set")
+	assert.Contains(t, out(), "ALGOLIA_SEARCH_HOSTS is set")
+	assert.Contains(t, out(), "c1-test-1.algolianet.com")
+	assert.NotContains(t, out(), "env-key")
+}
+
+func TestStatus_NeverTriggersLogin(t *testing.T) {
+	clearEnv(t)
+	keyring.MockInit()
+	auth.ClearToken()
+	f, out := test.NewFactory(false, nil, &test.ConfigStub{}, "")
+
+	_, err := test.Execute(NewStatusCmd(f), "", out)
+
+	require.Error(t, err)
+	assert.NotContains(t, out.String(), "Opening browser")
+}
+
+func TestStatus_TokenNeedingRefreshStillSignedIn(t *testing.T) {
+	clearEnv(t)
+	cfg := test.NewDefaultConfigStub()
+	cfg.CurrentProfile.ApplicationID = "APP1"
+	cfg.CurrentProfile.APIKey = "key-1"
+	token := &auth.StoredToken{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		ExpiresAt:    time.Now().Unix() - 3600,
+		Email:        "user@example.com",
+	}
+	opts, _, out := newTestOpts(cfg, token)
+
+	err := runStatusCmd(opts)
+
+	require.NoError(t, err)
+	assert.Contains(t, out(), "Signed in as user@example.com")
+	assert.Contains(t, out(), "refreshes automatically")
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -165,10 +165,9 @@ func Execute() (code exitCode) {
 		if auth.IsAuthCheckEnabled(cmd) {
 			if err := auth.CheckAuth(&cfg); err != nil {
 				fmt.Fprintf(stderr, "Authentication error: %s\n", err)
-				fmt.Fprintln(
-					stderr,
-					"Please run `algolia auth login` to get started.",
-				)
+				if hint := authRemediation(err); hint != "" {
+					fmt.Fprintln(stderr, hint)
+				}
 				return authError
 			}
 
@@ -268,6 +267,17 @@ func Execute() (code exitCode) {
 	}
 
 	return exitOK
+}
+
+func authRemediation(err error) string {
+	if errors.Is(err, config.ErrAPIKeyMissingFromKeychain) {
+		return ""
+	}
+	if (errors.Is(err, config.ErrApplicationIDNotConfigured) || errors.Is(err, config.ErrAPIKeyNotConfigured)) &&
+		auth.LoadToken() != nil {
+		return "You're signed in, but no application is selected.\nRun `algolia application select`, or pass --application-id."
+	}
+	return "Please run `algolia auth login` to get started."
 }
 
 // identifyNewlyAuthenticatedUser re-sends an Identify when the user signed in

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -98,7 +98,8 @@ func (p *Profile) GetAPIKey() (string, error) {
 			// The application is set but its key isn't in this machine's
 			// keychain (e.g. state.toml synced across machines without it).
 			return "", fmt.Errorf(
-				"no API key stored in your keychain for the current application %q; run `algolia application select` to store one, or set ALGOLIA_API_KEY",
+				"%w %q; run `algolia application select` to store one, or set ALGOLIA_API_KEY",
+				ErrAPIKeyMissingFromKeychain,
 				appID,
 			)
 		}

--- a/pkg/config/resolution_test.go
+++ b/pkg/config/resolution_test.go
@@ -249,6 +249,7 @@ func TestProfile_GetAPIKey_ActiveAppWithoutKeyErrors(t *testing.T) {
 }
 
 func TestProfile_GetSearchHosts_FromState(t *testing.T) {
+	t.Setenv("ALGOLIA_SEARCH_HOSTS", "")
 	path := filepath.Join(t.TempDir(), "state.toml")
 	require.NoError(t, os.WriteFile(path, []byte(
 		"current_application_id = \"APP1\"\n\n[applications.APP1]\nalias = \"prod\"\nsearch_hosts = [\"h1\", \"h2\"]\n",
@@ -261,6 +262,7 @@ func TestProfile_GetSearchHosts_FromState(t *testing.T) {
 }
 
 func TestProfile_GetSearchHosts_StateEmptyFallsBackToConfigToml(t *testing.T) {
+	t.Setenv("ALGOLIA_SEARCH_HOSTS", "")
 	statePath := filepath.Join(t.TempDir(), "state.toml")
 	require.NoError(
 		t,

--- a/pkg/config/validators.go
+++ b/pkg/config/validators.go
@@ -9,6 +9,8 @@ var (
 	ErrAPIKeyNotConfigured = errors.New("you have not configured your API key yet")
 	// ErrApplicationIDNotConfigured is the error returned when the loaded profile is missing the application_id property
 	ErrApplicationIDNotConfigured = errors.New("you have not configured your Application ID yet")
+	// ErrAPIKeyMissingFromKeychain is the error returned when the current application has no API key in the OS keychain
+	ErrAPIKeyMissingFromKeychain = errors.New("no API key stored in your keychain for the current application")
 
 	// ErrCrawlerAPIKeyNotConfigured is the error returned when the loaded profile is missing the crawler_api_key property
 	ErrCrawlerAPIKeyNotConfigured = errors.New("you have not configured your Crawler API key yet")


### PR DESCRIPTION
## What

- New `algolia auth status`: reports whether you're signed in (and as whom), which application is current, and whether an API key is available — with a non-zero exit code when neither a session nor API credentials are found. Strictly read-only: never prompts, opens a browser, or mutates stored credentials (unlike `auth get`, which triggers the OAuth flow when logged out). Flags active environment overrides (`ALGOLIA_APPLICATION_ID`, `ALGOLIA_API_KEY`, `ALGOLIA_ADMIN_API_KEY` deprecated, `ALGOLIA_SEARCH_HOSTS` with its value) so misdirected requests are diagnosable at a glance.
- The `auth` group description now mentions sign-up and status.
- Actionable auth error hints: when you're signed in but no application is selected, the failure now says `Run algolia application select, or pass --application-id` instead of the misleading `Please run algolia auth login`; the keychain-missing error keeps its own remediation without a contradictory extra line.
- `auth get` no longer panics (nil dereference) when authentication succeeds but the token cannot be persisted to the OS keychain — it returns a clear error instead.

### Why the pkg/config changes are in this PR

- `validators.go` + `profile.go`: the hint logic in `root.go` needs to distinguish "key missing from keychain" from the generic auth errors via `errors.Is`, so the existing inline error string becomes the `ErrAPIKeyMissingFromKeychain` sentinel, wrapped with `%w` where it was produced. The user-facing message is byte-for-byte identical.
- `resolution_test.go`: pre-existing flake surfaced while running the suite for this PR — the `GetSearchHosts` tests read the ambient environment, so they fail on any machine where the repo's `.env` (direnv) is loaded. Two `t.Setenv` lines neutralize it. Happy to split it out if preferred.

## Test

```
algolia auth status                                        # signed in: ✓ session, ✓ current app, ✓ API key
ALGOLIA_SEARCH_HOSTS=c1-test-1.algolianet.com algolia auth status   # warns that API requests go to that host
XDG_CONFIG_HOME=$(mktemp -d) ALGOLIA_APPLICATION_ID= ALGOLIA_API_KEY= algolia auth status; echo $?   # exit 1 when nothing usable
```