### PR TITLE
fix(application): persist configuration when create uses structured output

### DIFF
--- a/pkg/cmd/application/create/create.go
+++ b/pkg/cmd/application/create/create.go
@@ -287,15 +287,13 @@ func createApplication(
 				"  Add a payment method if needed, then retry with: algolia application upgrade --plan %s\n",
 				target.ID,
 			)
-			if !opts.structuredOutput() {
-				_ = apputil.ConfigureProfile(
-					opts.IO,
-					opts.Config,
-					appDetails,
-					opts.ProfileName,
-					opts.Default,
-				)
-			}
+			_ = apputil.ConfigureProfile(
+				opts.IO,
+				opts.Config,
+				appDetails,
+				opts.ProfileName,
+				opts.Default,
+			)
 			return result, fmt.Errorf(
 				"failed to apply the %q plan to application %s: %w",
 				target.Name,
@@ -312,6 +310,17 @@ func createApplication(
 		)
 	}
 
+	tracker.SetStep(telemetry.StepProfileConfigure)
+	if err := apputil.ConfigureProfile(
+		opts.IO,
+		opts.Config,
+		appDetails,
+		opts.ProfileName,
+		opts.Default,
+	); err != nil {
+		return result, err
+	}
+
 	if opts.structuredOutput() {
 		p, err := opts.PrintFlags.ToPrinter()
 		if err != nil {
@@ -319,15 +328,7 @@ func createApplication(
 		}
 		return result, p.Print(opts.IO, appDetails)
 	}
-
-	tracker.SetStep(telemetry.StepProfileConfigure)
-	return result, apputil.ConfigureProfile(
-		opts.IO,
-		opts.Config,
-		appDetails,
-		opts.ProfileName,
-		opts.Default,
-	)
+	return result, nil
 }
 
 func (opts *CreateOptions) structuredOutput() bool {

--- a/pkg/cmd/application/create/create_test.go
+++ b/pkg/cmd/application/create/create_test.go
@@ -242,7 +242,7 @@ func newOpts(
 	t.Helper()
 	seedToken(t)
 
-	f, out := test.NewFactory(isTTY, nil, nil, "")
+	f, out := test.NewFactory(isTTY, nil, test.NewDefaultConfigStub(), "")
 	opened := new(string)
 	opts := &CreateOptions{
 		IO:           f.IOStreams,
@@ -275,6 +275,21 @@ func TestRun_FreeNonInteractive(t *testing.T) {
 	require.NoError(t, runCreateCmd(context.Background(), opts))
 	assert.Equal(t, 1, srv.createCalls)
 	assert.Equal(t, 0, srv.patchCalls)
+	assert.Contains(t, out.String(), "APP1")
+}
+
+func TestRun_StructuredOutputPersistsProfile(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	opts, out, _ := newOpts(t, srv, false)
+	cfg := opts.Config.(*test.ConfigStub)
+	opts.AcceptTerms = true
+	opts.Default = true
+
+	require.NoError(t, runCreateCmd(context.Background(), opts))
+	assert.Equal(t, "APP1", cfg.CurrentAppID)
+	assert.Equal(t, "test-api-key", cfg.SavedApps["APP1"].APIKey)
 	assert.Contains(t, out.String(), "APP1")
 }
 


### PR DESCRIPTION
## What

- `application create -o/--output ...` returned right after printing, skipping the configuration step entirely: `--default` and `--profile-name` were silently ignored, and the next command failed with "you have not configured your Application ID yet" even though the app (and its API key) had just been created. The command now persists (OS keychain + state.toml) before printing the structured output — same behavior as the text mode, `application select`, `auth login` and `auth signup`.
- The paid-plan partial-failure branch (app created on Free, plan change failed) persists regardless of the output mode too.

## Test

```sh
algolia application create --name "Demo" --region CA --accept-terms --default -o json
algolia indices list        # works immediately: app selected, key stored
algolia auth status         # ✓ Current application + ✓ API key
```