### PR TITLE
docs: add Get Started section to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,8 @@ task build
 
 `task build` runs `go generate ./...` first, then produces the `algolia` binary at the root of the repository.
 
+You can then use it by doing `./algolia your_command ...`
+
 Build-time defaults (dashboard URL, OAuth client ID, and so on) are injected from environment variables. If you need non-default values, copy [`.env.example`](.env.example) to `.env` and fill it in.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -78,6 +78,35 @@ To build the Algolia CLI from source, you'll need:
 1. Clone the repo: `git clone https://github.com/algolia/cli.git algolia-cli && cd algolia-cli`
 1. Run: `task build`
 
+## Get started
+
+### Sign in
+
+Sign in through the browser (this also lets you sign up if you don't have an account yet):
+
+```sh
+algolia auth login
+```
+
+If your account has no application, the CLI prompts you to create one.
+On a machine without a browser (SSH, container), use `algolia auth login --no-browser`.
+Check your status anytime with `algolia auth status`.
+
+### Choose an application
+
+```sh
+algolia application list                                 # list your applications
+algolia application select                               # set the current one
+algolia application create --name "My App" --region EU   # regions: EU, UK, USC, USE, USW
+```
+
+### Index and search your first records
+
+```sh
+algolia objects import MOVIES -F movies.ndjson           # import records into the MOVIES index
+algolia search MOVIES --query "toy story"                # search them
+```
+
 ## Support
 
 If you found an issue with the Algolia CLI,


### PR DESCRIPTION
## What

- Add a "Get started" section to the README: sign in (`algolia auth login`), choose an application (`list` / `select` / `create`), and a first index + search micro-action.
- Add a short note in `CONTRIBUTING.md` on how to run the locally built binary (`./algolia your_command ...`).

[GROUT-327]

[GROUT-327]: https://algolia.atlassian.net/browse/GROUT-327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ