### PR TITLE
docs: add quotes around description in MDX template

### DIFF
--- a/internal/docs/mdx.tpl
+++ b/internal/docs/mdx.tpl
@@ -1,6 +1,6 @@
 ---
 title: {{ .Name }}
-description: {{ .Description }}
+description: "{{ .Description }}"
 public: true
 ---
 


### PR DESCRIPTION
Add `"` quotes around the description in the MDX templates. The `profile` commands have `[Deprecated]` in their description, so it must be quoted in YAML frontmatter.