### PR TITLE
fix(application): offer billing page on paid plan change

### DIFF
--- a/pkg/cmd/application/create/create.go
+++ b/pkg/cmd/application/create/create.go
@@ -237,7 +237,7 @@ func createApplication(
 			(user != nil && !user.HasPaymentMethod)
 		if billingMissing {
 			result.abortReason = telemetry.AbortReasonBillingRequired
-			return result, offerBilling(opts, client, *target)
+			return result, apputil.OfferBilling(opts.IO, opts.Browser, client.DashboardURL, *target)
 		}
 	}
 
@@ -428,42 +428,6 @@ func confirmToS(opts *CreateOptions, plan dashboard.Plan) (bool, error) {
 		return false, err
 	}
 	return accepted, nil
-}
-
-// offerBilling tells the user a paid plan needs billing and offers the billing page.
-func offerBilling(opts *CreateOptions, client *dashboard.Client, plan dashboard.Plan) error {
-	cs := opts.IO.ColorScheme()
-	url := client.DashboardURL + "/account/billing/details"
-
-	fmt.Fprintf(
-		opts.IO.Out,
-		"\nThe %s plan requires a payment method on file before a paid application can be provisioned.\nThe CLI can't collect card details.\n",
-		cs.Bold(plan.Name),
-	)
-
-	if opts.IO.CanPrompt() && opts.IO.IsStdoutTTY() {
-		browser := opts.Browser
-		if browser == nil {
-			browser = pkgopen.Browser
-		}
-		open := true
-		if err := prompt.Confirm("Open the billing page to add a payment method?", &open); err != nil {
-			return err
-		}
-		if !open {
-			return nil
-		}
-		fmt.Fprintf(opts.IO.Out, "Opening %s\n", cs.Bold(url))
-		return browser(url)
-	}
-
-	fmt.Fprintf(
-		opts.IO.Out,
-		"Add a payment method here, then re-run with --plan %s:\n%s\n",
-		plan.ID,
-		url,
-	)
-	return fmt.Errorf("the %q plan requires a payment method; none is on file", plan.Name)
 }
 
 // callWithReauth runs fn, re-authenticating once and retrying on an expired session.

--- a/pkg/cmd/application/planchange/planchange.go
+++ b/pkg/cmd/application/planchange/planchange.go
@@ -533,6 +533,9 @@ func pickPlan(candidates []dashboard.Plan) (*dashboard.Plan, error) {
 	}
 	labels := make([]string, len(candidates))
 	for i, p := range candidates {
+		if p.Price == "" {
+			p.Price = "Pay as you go"
+		}
 		labels[i] = fmt.Sprintf("%s — %s", p.Name, p.Price)
 	}
 	var selected int

--- a/pkg/cmd/application/planchange/planchange.go
+++ b/pkg/cmd/application/planchange/planchange.go
@@ -175,7 +175,7 @@ func changePlan(
 		result.fromPlan = currentPlanTelemetryID(plans, app)
 	}
 
-	target, err := resolveTarget(opts, appID, app, plans)
+	target, err := resolveTarget(opts, appID, app, plans, user)
 	if err != nil {
 		return result, err
 	}
@@ -197,15 +197,13 @@ func changePlan(
 		return result, nil
 	}
 
-	// Paid plans require a payment method that the CLI cannot collect. Only
-	// block when we positively know there is none (user fetched, flag false);
-	// otherwise defer to the server.
-	if !target.IsFree() && user != nil && !user.HasPaymentMethod {
+	// Paid plans require a payment method that the CLI cannot collect. Block
+	// when the server hides the plan (paid plans appear only once billing is
+	// on file) or when the user record says no payment method is on file.
+	if !target.IsFree() &&
+		(!apputil.PlanAvailable(plans, target.ID) || (user != nil && !user.HasPaymentMethod)) {
 		result.abortReason = telemetry.AbortReasonBillingRequired
-		return result, fmt.Errorf(
-			"the %q plan requires a payment method, which the CLI can't collect; add one in the Algolia dashboard (Settings → Billing) and try again",
-			target.Name,
-		)
+		return result, apputil.OfferBilling(opts.IO, opts.Browser, client.DashboardURL, *target)
 	}
 
 	if opts.DryRun {
@@ -335,12 +333,20 @@ func resolveTarget(
 	appID string,
 	app *dashboard.Application,
 	plans []dashboard.Plan,
+	user *dashboard.DashboardUser,
 ) (*dashboard.Plan, error) {
 	if opts.Plan != "" {
-		return resolvePlan(plans, opts.Plan)
+		target, err := resolvePlan(plans, opts.Plan)
+		if err == nil {
+			return target, nil
+		}
+		if paid := apputil.KnownPaidPlan(opts.Plan); paid != nil {
+			return paid, nil
+		}
+		return nil, err
 	}
 
-	candidates := filterByDirection(plans, app, opts.Direction)
+	candidates := filterByDirection(withKnownPaidPlans(plans, user), app, opts.Direction)
 
 	if len(candidates) == 0 {
 		reportNoCandidates(opts, appID, app, opts.Direction)
@@ -392,6 +398,19 @@ func filterByDirection(
 		return plans[:idx]
 	}
 	return plans[idx+1:]
+}
+
+func withKnownPaidPlans(plans []dashboard.Plan, user *dashboard.DashboardUser) []dashboard.Plan {
+	if user == nil || user.HasPaymentMethod {
+		return plans
+	}
+	augmented := append([]dashboard.Plan(nil), plans...)
+	for _, p := range apputil.KnownPaidPlans() {
+		if !apputil.PlanAvailable(augmented, p.ID) {
+			augmented = append(augmented, p)
+		}
+	}
+	return augmented
 }
 
 // normalizePlanKey normalizes a plan label/name for comparison; the CLI joins

--- a/pkg/cmd/application/planchange/planchange_test.go
+++ b/pkg/cmd/application/planchange/planchange_test.go
@@ -156,6 +156,7 @@ type planChangeServer struct {
 	patchCalls       int
 	lastPlan         string
 	currentPlanLabel string
+	freeOnly         bool
 }
 
 // newServer spins up a dashboard stub. userJSON is the raw GET /1/user body;
@@ -168,8 +169,12 @@ func newServer(t *testing.T, userJSON string) *planChangeServer {
 	mux.HandleFunc(
 		"/1/plan-templates/self-serve",
 		func(w http.ResponseWriter, _ *http.Request) {
+			templates := samplePlanTemplates()
+			if srv.freeOnly {
+				templates = templates[:1]
+			}
 			require.NoError(t, json.NewEncoder(w).Encode(dashboard.PlanTemplatesResponse{
-				Data: samplePlanTemplates(),
+				Data: templates,
 			}))
 		},
 	)
@@ -296,7 +301,7 @@ func TestRun_BillingBlock(t *testing.T) {
 	srv := newServer(t, `{"has_payment_method": false}`)
 	defer srv.Close()
 
-	opts, _, _ := newOpts(t, srv, false)
+	opts, out, _ := newOpts(t, srv, false)
 	opts.Plan = "grow"
 	opts.AcceptTerms = true
 
@@ -304,6 +309,40 @@ func TestRun_BillingBlock(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "payment method")
 	assert.Equal(t, 0, srv.patchCalls)
+	assert.Contains(t, out.String(), "https://dashboard.algolia.com/account/billing/details")
+	assert.Contains(t, out.String(), "--plan grow")
+}
+
+func TestRun_PaidNoBillingInteractiveOpensBilling(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	defer prompt.StubConfirm(true)()
+
+	opts, _, opened := newOpts(t, srv, true)
+	opts.Plan = "grow"
+
+	require.NoError(t, Run(context.Background(), opts))
+	assert.Equal(t, 0, srv.patchCalls)
+	assert.Equal(
+		t,
+		"https://dashboard.algolia.com/account/billing/details",
+		*opened,
+	)
+}
+
+func TestRun_PaidNoBillingInteractiveDeclineOpen(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	defer prompt.StubConfirm(false)()
+
+	opts, _, opened := newOpts(t, srv, true)
+	opts.Plan = "grow"
+
+	require.NoError(t, Run(context.Background(), opts))
+	assert.Equal(t, 0, srv.patchCalls)
+	assert.Empty(t, *opened)
 }
 
 func TestRun_ToSDeclineAborts(t *testing.T) {
@@ -525,4 +564,86 @@ func TestRun_UnknownCurrentPlanShowsAllPlans(t *testing.T) {
 	require.NoError(t, Run(context.Background(), opts))
 	assert.Equal(t, 1, srv.patchCalls)
 	assert.Equal(t, "build", srv.lastPlan)
+}
+
+func TestRun_PlanFlagPaidFreeOnlyServerBlocks(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	srv.freeOnly = true
+	srv.currentPlanLabel = "Build"
+	defer srv.Close()
+
+	opts, out, _ := newOpts(t, srv, false)
+	opts.Plan = "grow"
+	opts.AcceptTerms = true
+
+	err := Run(context.Background(), opts)
+	require.Error(t, err)
+	assert.Equal(t, 0, srv.patchCalls)
+	assert.Contains(t, out.String(), "https://dashboard.algolia.com/account/billing/details")
+	assert.Contains(t, out.String(), "--plan grow")
+}
+
+func TestRun_PlanFlagPaidFreeOnlyServerInteractiveOpensBilling(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	srv.freeOnly = true
+	srv.currentPlanLabel = "Build"
+	defer srv.Close()
+
+	defer prompt.StubConfirm(true)()
+
+	opts, _, opened := newOpts(t, srv, true)
+	opts.Plan = "grow"
+
+	require.NoError(t, Run(context.Background(), opts))
+	assert.Equal(t, 0, srv.patchCalls)
+	assert.Equal(t, "https://dashboard.algolia.com/account/billing/details", *opened)
+}
+
+func TestRun_InteractivePickerFreeOnlyServerOffersPaidThenBilling(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	srv.freeOnly = true
+	srv.currentPlanLabel = "Build"
+	defer srv.Close()
+
+	stubPicker(t, 0)
+	defer prompt.StubConfirm(true)()
+
+	opts, _, opened := newOpts(t, srv, true)
+	opts.Direction = DirectionUpgrade
+
+	require.NoError(t, Run(context.Background(), opts))
+	assert.Equal(t, 0, srv.patchCalls)
+	assert.Equal(t, "https://dashboard.algolia.com/account/billing/details", *opened)
+}
+
+func TestRun_NonInteractiveFreeOnlyServerListsPaidPlans(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": false}`)
+	srv.freeOnly = true
+	srv.currentPlanLabel = "Build"
+	defer srv.Close()
+
+	opts, out, _ := newOpts(t, srv, false)
+	opts.Direction = DirectionUpgrade
+
+	err := Run(context.Background(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--plan is required")
+	assert.Contains(t, err.Error(), "grow, grow-plus")
+	assert.NotContains(t, out.String(), "nothing to upgrade")
+	assert.Equal(t, 0, srv.patchCalls)
+}
+
+func TestRun_FreeOnlyServerWithBillingReportsHighestPlan(t *testing.T) {
+	srv := newServer(t, `{"has_payment_method": true}`)
+	srv.freeOnly = true
+	srv.currentPlanLabel = "Build"
+	defer srv.Close()
+
+	opts, out, _ := newOpts(t, srv, false)
+	opts.Direction = DirectionUpgrade
+
+	require.NoError(t, Run(context.Background(), opts))
+	assert.Equal(t, 0, srv.patchCalls)
+	assert.Contains(t, out.String(), "already on the highest")
+	assert.Contains(t, out.String(), "nothing to upgrade")
 }

--- a/pkg/cmd/application/plans/plans.go
+++ b/pkg/cmd/application/plans/plans.go
@@ -8,11 +8,14 @@ import (
 
 	"github.com/algolia/cli/api/dashboard"
 	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmd/shared/apputil"
 	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/config"
 	"github.com/algolia/cli/pkg/iostreams"
 	"github.com/algolia/cli/pkg/validators"
 )
+
+const reasonNoPaymentMethod = "no payment method on file"
 
 type PlansOptions struct {
 	IO     *iostreams.IOStreams
@@ -21,6 +24,17 @@ type PlansOptions struct {
 	PrintFlags *cmdutil.PrintFlags
 
 	NewDashboardClient func(clientID string) *dashboard.Client
+}
+
+type planOutput struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Description       string `json:"description"`
+	Type              string `json:"type"`
+	Price             string `json:"price"`
+	AcceptTerms       string `json:"accept_terms"`
+	Available         bool   `json:"available"`
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
 }
 
 func NewPlansCmd(f *cmdutil.Factory) *cobra.Command {
@@ -88,24 +102,76 @@ func runPlansCmd(opts *PlansOptions) error {
 		}
 	}
 
+	var user *dashboard.DashboardUser
+	opts.IO.StartProgressIndicatorWithLabel("Checking account")
+	u, userErr := client.GetUser(accessToken)
+	opts.IO.StopProgressIndicator()
+	if userErr == nil {
+		user = u
+	}
+
+	outputs := buildPlanOutputs(plans, user)
+
 	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
 		p, err := opts.PrintFlags.ToPrinter()
 		if err != nil {
 			return err
 		}
-		return p.Print(opts.IO, plans)
+		return p.Print(opts.IO, outputs)
 	}
 
-	if len(plans) == 0 {
+	if len(outputs) == 0 {
 		fmt.Fprintf(opts.IO.Out, "%s No plans available.\n", cs.WarningIcon())
 		return nil
 	}
 
-	for _, plan := range plans {
+	for _, plan := range outputs {
+		if !plan.Available {
+			fmt.Fprintf(
+				opts.IO.Out,
+				"%s  %s\n",
+				cs.Bold(plan.Name),
+				cs.Yellowf("(unavailable: %s — add billing to unlock)", plan.UnavailableReason),
+			)
+			continue
+		}
 		fmt.Fprintf(opts.IO.Out, "%s  %s\n", cs.Bold(plan.Name), plan.Price)
 		if plan.Description != "" {
 			fmt.Fprintf(opts.IO.Out, "  %s\n", plan.Description)
 		}
 	}
 	return nil
+}
+
+func buildPlanOutputs(plans []dashboard.Plan, user *dashboard.DashboardUser) []planOutput {
+	outputs := make([]planOutput, 0, len(plans))
+	for _, p := range plans {
+		outputs = append(outputs, planOutput{
+			ID:          p.ID,
+			Name:        p.Name,
+			Description: p.Description,
+			Type:        p.Type,
+			Price:       p.Price,
+			AcceptTerms: p.AcceptTerms,
+			Available:   true,
+		})
+	}
+
+	if user == nil || user.HasPaymentMethod {
+		return outputs
+	}
+
+	for _, p := range apputil.KnownPaidPlans() {
+		if apputil.PlanAvailable(plans, p.ID) {
+			continue
+		}
+		outputs = append(outputs, planOutput{
+			ID:                p.ID,
+			Name:              p.Name,
+			Type:              p.Type,
+			Available:         false,
+			UnavailableReason: reasonNoPaymentMethod,
+		})
+	}
+	return outputs
 }

--- a/pkg/cmd/application/plans/plans_test.go
+++ b/pkg/cmd/application/plans/plans_test.go
@@ -27,39 +27,55 @@ func seedToken(t *testing.T) {
 	}))
 }
 
-func newServer(t *testing.T) *httptest.Server {
+func buildTemplate() dashboard.PlanTemplateResource {
+	return dashboard.PlanTemplateResource{
+		ID:   "build",
+		Type: "plan_template",
+		Attributes: dashboard.PlanTemplateAttributes{
+			Name:          "Build",
+			Description:   "Free forever Search & Discovery API.",
+			Type:          "free",
+			Configuration: dashboard.PlanTemplateConfiguration{Plan: "build"},
+		},
+	}
+}
+
+func growTemplate() dashboard.PlanTemplateResource {
+	return dashboard.PlanTemplateResource{
+		ID:   "grow",
+		Type: "plan_template",
+		Attributes: dashboard.PlanTemplateAttributes{
+			Name:          "Grow",
+			Description:   "Best-in-class Search & Discovery API.",
+			Type:          "freeform",
+			Freeform:      "$0.50 / 1,000 Requests",
+			Configuration: dashboard.PlanTemplateConfiguration{Plan: "grow"},
+		},
+	}
+}
+
+func newServer(t *testing.T, freeOnly bool, userJSON string) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc(
 		"/1/plan-templates/self-serve",
 		func(w http.ResponseWriter, _ *http.Request) {
+			data := []dashboard.PlanTemplateResource{buildTemplate()}
+			if !freeOnly {
+				data = append(data, growTemplate())
+			}
 			require.NoError(t, json.NewEncoder(w).Encode(dashboard.PlanTemplatesResponse{
-				Data: []dashboard.PlanTemplateResource{
-					{
-						ID:   "build",
-						Type: "plan_template",
-						Attributes: dashboard.PlanTemplateAttributes{
-							Name:          "Build",
-							Description:   "Free forever Search & Discovery API.",
-							Type:          "free",
-							Configuration: dashboard.PlanTemplateConfiguration{Plan: "build"},
-						},
-					},
-					{
-						ID:   "grow",
-						Type: "plan_template",
-						Attributes: dashboard.PlanTemplateAttributes{
-							Name:          "Grow",
-							Description:   "Best-in-class Search & Discovery API.",
-							Type:          "freeform",
-							Freeform:      "$0.50 / 1,000 Requests",
-							Configuration: dashboard.PlanTemplateConfiguration{Plan: "grow"},
-						},
-					},
-				},
+				Data: data,
 			}))
 		},
 	)
+	mux.HandleFunc("/1/user", func(w http.ResponseWriter, _ *http.Request) {
+		if userJSON == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(json.RawMessage(userJSON)))
+	})
 	return httptest.NewServer(mux)
 }
 
@@ -91,7 +107,7 @@ func newOpts(
 }
 
 func Test_runPlansCmd(t *testing.T) {
-	srv := newServer(t)
+	srv := newServer(t, false, `{"has_payment_method": true}`)
 	defer srv.Close()
 
 	opts, out := newOpts(t, srv, true, "")
@@ -102,10 +118,11 @@ func Test_runPlansCmd(t *testing.T) {
 	assert.Contains(t, got, "Free")
 	assert.Contains(t, got, "Grow")
 	assert.Contains(t, got, "$0.50 / 1,000 Requests")
+	assert.NotContains(t, got, "unavailable")
 }
 
 func Test_runPlansCmd_outputJSON(t *testing.T) {
-	srv := newServer(t)
+	srv := newServer(t, false, `{"has_payment_method": true}`)
 	defer srv.Close()
 
 	opts, out := newOpts(t, srv, false, "json")
@@ -115,4 +132,49 @@ func Test_runPlansCmd_outputJSON(t *testing.T) {
 	assert.Contains(t, got, `"name":"Build"`)
 	assert.Contains(t, got, `"price":"Free"`)
 	assert.Contains(t, got, `"name":"Grow"`)
+	assert.Contains(t, got, `"available":true`)
+	assert.NotContains(t, got, "unavailable_reason")
+}
+
+func Test_runPlansCmd_noPaymentMethod(t *testing.T) {
+	srv := newServer(t, true, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, true, "")
+	require.NoError(t, runPlansCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, "Build")
+	assert.Contains(t, got, "Grow")
+	assert.Contains(t, got, "Grow Plus")
+	assert.Contains(t, got, "unavailable: no payment method on file — add billing to unlock")
+}
+
+func Test_runPlansCmd_noPaymentMethod_outputJSON(t *testing.T) {
+	srv := newServer(t, true, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, false, "json")
+	require.NoError(t, runPlansCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, `"name":"Build"`)
+	assert.Contains(t, got, `"available":true`)
+	assert.Contains(t, got, `"id":"grow"`)
+	assert.Contains(t, got, `"id":"grow-plus"`)
+	assert.Contains(t, got, `"available":false`)
+	assert.Contains(t, got, `"unavailable_reason":"no payment method on file"`)
+}
+
+func Test_runPlansCmd_userFetchFailed(t *testing.T) {
+	srv := newServer(t, true, "")
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, true, "")
+	require.NoError(t, runPlansCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, "Build")
+	assert.NotContains(t, got, "Grow")
+	assert.NotContains(t, got, "unavailable")
 }

--- a/pkg/cmd/shared/apputil/billing.go
+++ b/pkg/cmd/shared/apputil/billing.go
@@ -1,0 +1,49 @@
+package apputil
+
+import (
+	"fmt"
+
+	"github.com/algolia/cli/api/dashboard"
+	"github.com/algolia/cli/pkg/iostreams"
+	pkgopen "github.com/algolia/cli/pkg/open"
+	"github.com/algolia/cli/pkg/prompt"
+)
+
+func OfferBilling(
+	io *iostreams.IOStreams,
+	browser func(string) error,
+	dashboardURL string,
+	plan dashboard.Plan,
+) error {
+	cs := io.ColorScheme()
+	url := dashboardURL + "/account/billing/details"
+
+	fmt.Fprintf(
+		io.Out,
+		"\nThe %s plan requires a payment method on file before a paid application can be provisioned.\nThe CLI can't collect card details.\n",
+		cs.Bold(plan.Name),
+	)
+
+	if io.CanPrompt() && io.IsStdoutTTY() {
+		if browser == nil {
+			browser = pkgopen.Browser
+		}
+		open := true
+		if err := prompt.Confirm("Open the billing page to add a payment method?", &open); err != nil {
+			return err
+		}
+		if !open {
+			return nil
+		}
+		fmt.Fprintf(io.Out, "Opening %s\n", cs.Bold(url))
+		return browser(url)
+	}
+
+	fmt.Fprintf(
+		io.Out,
+		"Add a payment method here, then re-run with --plan %s:\n%s\n",
+		plan.ID,
+		url,
+	)
+	return fmt.Errorf("the %q plan requires a payment method; none is on file", plan.Name)
+}

--- a/pkg/cmd/shared/apputil/plan.go
+++ b/pkg/cmd/shared/apputil/plan.go
@@ -37,6 +37,8 @@ var knownPaidPlanNames = map[string]string{
 	"grow-plus": "Grow Plus",
 }
 
+var knownPaidPlanOrder = []string{"grow", "grow-plus"}
+
 // KnownPaidPlan recognizes a documented paid --plan value even when the
 // self-serve endpoint omits it (paid plans appear only once billing is on file).
 func KnownPaidPlan(value string) *dashboard.Plan {
@@ -49,6 +51,16 @@ func KnownPaidPlan(value string) *dashboard.Plan {
 		Name: name,
 		Type: "freeform",
 	}
+}
+
+func KnownPaidPlans() []dashboard.Plan {
+	plans := make([]dashboard.Plan, 0, len(knownPaidPlanOrder))
+	for _, id := range knownPaidPlanOrder {
+		if p := KnownPaidPlan(id); p != nil {
+			plans = append(plans, *p)
+		}
+	}
+	return plans
 }
 
 // PlanAvailable reports whether a plan with the given id is in the list.


### PR DESCRIPTION
## What
- Extract `offerBilling` from `application create` into `apputil.OfferBilling`
- Offer to open the billing page from `application upgrade`/`downgrade` when no payment method is on file (was a plain error)
- Reach the offer even though the server hides paid plans without billing: `--plan` falls back to the known paid plans, the billing wall also triggers on server-side unavailability, and the upgrade picker lists the known paid plans (`apputil.KnownPaidPlans`)

## Test
- On an account without a payment method: `algolia application upgrade` → picker shows Grow / Grow Plus; pick one → explanation + "Open the billing page to add a payment method?" prompt; accept → browser opens `<dashboard>/account/billing/details`, no plan change
- Same but decline → command exits 0, no plan change
- Non-interactive: `algolia application upgrade < /dev/null` → `--plan is required in non-interactive mode (one of: grow, grow-plus)`, non-zero
- Non-interactive: `algolia application upgrade --plan grow < /dev/null` → billing URL + `--plan grow` re-run hint, non-zero
- On an account WITH a payment method already on the highest plan: `algolia application upgrade` → still "nothing to upgrade to", exit 0
- `algolia application create` with a paid plan and no payment method → unchanged behavior

[GROUT-409]

[GROUT-409]: https://algolia.atlassian.net/browse/GROUT-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ