### PR TITLE
feat(application): show unavailable plans with reason

### DIFF
--- a/pkg/cmd/application/planchange/planchange.go
+++ b/pkg/cmd/application/planchange/planchange.go
@@ -533,6 +533,9 @@ func pickPlan(candidates []dashboard.Plan) (*dashboard.Plan, error) {
 	}
 	labels := make([]string, len(candidates))
 	for i, p := range candidates {
+		if p.Price == "" {
+			p.Price = "Pay as you go"
+		}
 		labels[i] = fmt.Sprintf("%s — %s", p.Name, p.Price)
 	}
 	var selected int

--- a/pkg/cmd/application/plans/plans.go
+++ b/pkg/cmd/application/plans/plans.go
@@ -8,11 +8,14 @@ import (
 
 	"github.com/algolia/cli/api/dashboard"
 	"github.com/algolia/cli/pkg/auth"
+	"github.com/algolia/cli/pkg/cmd/shared/apputil"
 	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/config"
 	"github.com/algolia/cli/pkg/iostreams"
 	"github.com/algolia/cli/pkg/validators"
 )
+
+const reasonNoPaymentMethod = "no payment method on file"
 
 type PlansOptions struct {
 	IO     *iostreams.IOStreams
@@ -21,6 +24,17 @@ type PlansOptions struct {
 	PrintFlags *cmdutil.PrintFlags
 
 	NewDashboardClient func(clientID string) *dashboard.Client
+}
+
+type planOutput struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Description       string `json:"description"`
+	Type              string `json:"type"`
+	Price             string `json:"price"`
+	AcceptTerms       string `json:"accept_terms"`
+	Available         bool   `json:"available"`
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
 }
 
 func NewPlansCmd(f *cmdutil.Factory) *cobra.Command {
@@ -88,24 +102,76 @@ func runPlansCmd(opts *PlansOptions) error {
 		}
 	}
 
+	var user *dashboard.DashboardUser
+	opts.IO.StartProgressIndicatorWithLabel("Checking account")
+	u, userErr := client.GetUser(accessToken)
+	opts.IO.StopProgressIndicator()
+	if userErr == nil {
+		user = u
+	}
+
+	outputs := buildPlanOutputs(plans, user)
+
 	if opts.PrintFlags.OutputFlagSpecified() && opts.PrintFlags.OutputFormat != nil {
 		p, err := opts.PrintFlags.ToPrinter()
 		if err != nil {
 			return err
 		}
-		return p.Print(opts.IO, plans)
+		return p.Print(opts.IO, outputs)
 	}
 
-	if len(plans) == 0 {
+	if len(outputs) == 0 {
 		fmt.Fprintf(opts.IO.Out, "%s No plans available.\n", cs.WarningIcon())
 		return nil
 	}
 
-	for _, plan := range plans {
+	for _, plan := range outputs {
+		if !plan.Available {
+			fmt.Fprintf(
+				opts.IO.Out,
+				"%s  %s\n",
+				cs.Bold(plan.Name),
+				cs.Yellowf("(unavailable: %s — add billing to unlock)", plan.UnavailableReason),
+			)
+			continue
+		}
 		fmt.Fprintf(opts.IO.Out, "%s  %s\n", cs.Bold(plan.Name), plan.Price)
 		if plan.Description != "" {
 			fmt.Fprintf(opts.IO.Out, "  %s\n", plan.Description)
 		}
 	}
 	return nil
+}
+
+func buildPlanOutputs(plans []dashboard.Plan, user *dashboard.DashboardUser) []planOutput {
+	outputs := make([]planOutput, 0, len(plans))
+	for _, p := range plans {
+		outputs = append(outputs, planOutput{
+			ID:          p.ID,
+			Name:        p.Name,
+			Description: p.Description,
+			Type:        p.Type,
+			Price:       p.Price,
+			AcceptTerms: p.AcceptTerms,
+			Available:   true,
+		})
+	}
+
+	if user == nil || user.HasPaymentMethod {
+		return outputs
+	}
+
+	for _, p := range apputil.KnownPaidPlans() {
+		if apputil.PlanAvailable(plans, p.ID) {
+			continue
+		}
+		outputs = append(outputs, planOutput{
+			ID:                p.ID,
+			Name:              p.Name,
+			Type:              p.Type,
+			Available:         false,
+			UnavailableReason: reasonNoPaymentMethod,
+		})
+	}
+	return outputs
 }

--- a/pkg/cmd/application/plans/plans_test.go
+++ b/pkg/cmd/application/plans/plans_test.go
@@ -27,39 +27,55 @@ func seedToken(t *testing.T) {
 	}))
 }
 
-func newServer(t *testing.T) *httptest.Server {
+func buildTemplate() dashboard.PlanTemplateResource {
+	return dashboard.PlanTemplateResource{
+		ID:   "build",
+		Type: "plan_template",
+		Attributes: dashboard.PlanTemplateAttributes{
+			Name:          "Build",
+			Description:   "Free forever Search & Discovery API.",
+			Type:          "free",
+			Configuration: dashboard.PlanTemplateConfiguration{Plan: "build"},
+		},
+	}
+}
+
+func growTemplate() dashboard.PlanTemplateResource {
+	return dashboard.PlanTemplateResource{
+		ID:   "grow",
+		Type: "plan_template",
+		Attributes: dashboard.PlanTemplateAttributes{
+			Name:          "Grow",
+			Description:   "Best-in-class Search & Discovery API.",
+			Type:          "freeform",
+			Freeform:      "$0.50 / 1,000 Requests",
+			Configuration: dashboard.PlanTemplateConfiguration{Plan: "grow"},
+		},
+	}
+}
+
+func newServer(t *testing.T, freeOnly bool, userJSON string) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc(
 		"/1/plan-templates/self-serve",
 		func(w http.ResponseWriter, _ *http.Request) {
+			data := []dashboard.PlanTemplateResource{buildTemplate()}
+			if !freeOnly {
+				data = append(data, growTemplate())
+			}
 			require.NoError(t, json.NewEncoder(w).Encode(dashboard.PlanTemplatesResponse{
-				Data: []dashboard.PlanTemplateResource{
-					{
-						ID:   "build",
-						Type: "plan_template",
-						Attributes: dashboard.PlanTemplateAttributes{
-							Name:          "Build",
-							Description:   "Free forever Search & Discovery API.",
-							Type:          "free",
-							Configuration: dashboard.PlanTemplateConfiguration{Plan: "build"},
-						},
-					},
-					{
-						ID:   "grow",
-						Type: "plan_template",
-						Attributes: dashboard.PlanTemplateAttributes{
-							Name:          "Grow",
-							Description:   "Best-in-class Search & Discovery API.",
-							Type:          "freeform",
-							Freeform:      "$0.50 / 1,000 Requests",
-							Configuration: dashboard.PlanTemplateConfiguration{Plan: "grow"},
-						},
-					},
-				},
+				Data: data,
 			}))
 		},
 	)
+	mux.HandleFunc("/1/user", func(w http.ResponseWriter, _ *http.Request) {
+		if userJSON == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(json.RawMessage(userJSON)))
+	})
 	return httptest.NewServer(mux)
 }
 
@@ -91,7 +107,7 @@ func newOpts(
 }
 
 func Test_runPlansCmd(t *testing.T) {
-	srv := newServer(t)
+	srv := newServer(t, false, `{"has_payment_method": true}`)
 	defer srv.Close()
 
 	opts, out := newOpts(t, srv, true, "")
@@ -102,10 +118,11 @@ func Test_runPlansCmd(t *testing.T) {
 	assert.Contains(t, got, "Free")
 	assert.Contains(t, got, "Grow")
 	assert.Contains(t, got, "$0.50 / 1,000 Requests")
+	assert.NotContains(t, got, "unavailable")
 }
 
 func Test_runPlansCmd_outputJSON(t *testing.T) {
-	srv := newServer(t)
+	srv := newServer(t, false, `{"has_payment_method": true}`)
 	defer srv.Close()
 
 	opts, out := newOpts(t, srv, false, "json")
@@ -115,4 +132,49 @@ func Test_runPlansCmd_outputJSON(t *testing.T) {
 	assert.Contains(t, got, `"name":"Build"`)
 	assert.Contains(t, got, `"price":"Free"`)
 	assert.Contains(t, got, `"name":"Grow"`)
+	assert.Contains(t, got, `"available":true`)
+	assert.NotContains(t, got, "unavailable_reason")
+}
+
+func Test_runPlansCmd_noPaymentMethod(t *testing.T) {
+	srv := newServer(t, true, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, true, "")
+	require.NoError(t, runPlansCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, "Build")
+	assert.Contains(t, got, "Grow")
+	assert.Contains(t, got, "Grow Plus")
+	assert.Contains(t, got, "unavailable: no payment method on file — add billing to unlock")
+}
+
+func Test_runPlansCmd_noPaymentMethod_outputJSON(t *testing.T) {
+	srv := newServer(t, true, `{"has_payment_method": false}`)
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, false, "json")
+	require.NoError(t, runPlansCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, `"name":"Build"`)
+	assert.Contains(t, got, `"available":true`)
+	assert.Contains(t, got, `"id":"grow"`)
+	assert.Contains(t, got, `"id":"grow-plus"`)
+	assert.Contains(t, got, `"available":false`)
+	assert.Contains(t, got, `"unavailable_reason":"no payment method on file"`)
+}
+
+func Test_runPlansCmd_userFetchFailed(t *testing.T) {
+	srv := newServer(t, true, "")
+	defer srv.Close()
+
+	opts, out := newOpts(t, srv, true, "")
+	require.NoError(t, runPlansCmd(opts))
+
+	got := out.String()
+	assert.Contains(t, got, "Build")
+	assert.NotContains(t, got, "Grow")
+	assert.NotContains(t, got, "unavailable")
 }


### PR DESCRIPTION
## What
- `algolia application plans`: also list the paid plans the server hides when no payment method is on file, marked unavailable with the reason
- Structured output: add `available` and `unavailable_reason` fields; server-returned plans unchanged
- Stacked on #270 (reuses `apputil.KnownPaidPlans`)

## Test
- On an account without a payment method: `algolia application plans` → Build plus `Grow  (unavailable: no payment method on file — add billing to unlock)` and same for Grow Plus
- `algolia application plans -o json` → placeholders with `"available":false` + `"unavailable_reason":"no payment method on file"`, Build with `"available":true`
- On an account with a payment method: output unchanged from today, all plans `"available":true`

[GROUT-409]

[GROUT-409]: https://algolia.atlassian.net/browse/GROUT-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ